### PR TITLE
Changed volume field type to int

### DIFF
--- a/Embedded/MaxMix/MaxMix.ino
+++ b/Embedded/MaxMix/MaxMix.ino
@@ -82,7 +82,7 @@ struct Item
 {
   uint32_t id;                          // 4 Bytes (32 bit)
   char name[ITEM_BUFFER_NAME_SIZE];  // 36 Bytes (1 Bytes * 36 Chars)
-  uint8_t volume;                       // 1 Byte
+  int8_t volume;                        // 1 Byte
   uint8_t isMuted;                      // 1 Byte
                                         // 82 Bytes TOTAL
 };


### PR DESCRIPTION
## Issues
 - Fixes #37 
 - Resolves #
 - Closes #

## Description
Changed the volume variable type to int from uint to fix issue. 
An unsigned integer can not go below 0 so we can't clamp it to 0 if negative...

## Types of changes
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Compiled and tested requested changes
- [X] Updated the documentation, if necessary
- [X] Updated the LICENSES file, if necessary
- [X] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository
- [X] Requesting to **pull a topic/feature/bugfix branch**


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
