### PR TITLE
Generating better application names

### DIFF
--- a/Desktop/Application/MaxMix/MaxMix.csproj
+++ b/Desktop/Application/MaxMix/MaxMix.csproj
@@ -25,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Desktop/Application/MaxMix/Services/Audio/AudioSessionService.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioSessionService.cs
@@ -116,6 +116,9 @@ namespace MaxMix.Services.Audio
                     if (session2.IsSystemSoundSession)
                         continue;
 
+                    if (session2.Process == null)
+                        continue;
+
                     var wrapper = RegisterSession(session);
                     RaiseSessionCreated(wrapper.ProcessID, wrapper.DisplayName, wrapper.Volume, wrapper.IsMuted);
                 }

--- a/Desktop/Application/MaxMix/Services/Audio/AudioSessionWrapper.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioSessionWrapper.cs
@@ -84,15 +84,14 @@ namespace MaxMix.Services.Audio
         {
             get
             {
-                var displayName = _session2.DisplayName;
+                // Fallback chain to get a valid name for this session.
+                var displayName = _session2.Process.MainModule.FileVersionInfo.ProductName;
+                if (string.IsNullOrEmpty(displayName)) { displayName = _session2.DisplayName; }
                 if (string.IsNullOrEmpty(displayName)) { displayName = _session2.Process.ProcessName; }
                 if (string.IsNullOrEmpty(displayName)) { displayName = _session2.Process.MainWindowTitle; }
                 if (string.IsNullOrEmpty(displayName)) { displayName = "Unnamed"; }
 
-                // Capitalize first letter
-                displayName = char.ToUpper(displayName[0]) + displayName.Substring(1);
-
-                return displayName;
+                return Capitalize(displayName);
             }
         }
 
@@ -117,7 +116,21 @@ namespace MaxMix.Services.Audio
             get => _simpleAudio.IsMuted;
             set => _simpleAudio.IsMuted = value;
         }
-        #endregion                  
+        #endregion
+
+        #region Private Methods
+        // Capitalize the first letter of each word in the input string.
+        private string Capitalize(string arg)
+        {
+            var result = string.Empty;
+            var tokens = arg.Split(' ');
+            foreach (var token in tokens)
+                result += char.ToUpper(token[0]) + token.Substring(1) + " ";
+
+            result = result.Trim();
+            return result;
+        }
+        #endregion
 
         #region Event Handlers
         private void OnSimpleVolumeChanged(object sender, AudioSessionSimpleVolumeChangedEventArgs e)

--- a/Desktop/Application/MaxMix/Services/Audio/AudioSessionWrapper.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioSessionWrapper.cs
@@ -85,7 +85,7 @@ namespace MaxMix.Services.Audio
             get
             {
                 // Fallback chain to get a valid name for this session.
-                var displayName = _session2.Process.MainModule.FileVersionInfo.ProductName;
+                var displayName = _session2.Process.MainModule.FileVersionInfo.FileDescription;
                 if (string.IsNullOrEmpty(displayName)) { displayName = _session2.DisplayName; }
                 if (string.IsNullOrEmpty(displayName)) { displayName = _session2.Process.ProcessName; }
                 if (string.IsNullOrEmpty(displayName)) { displayName = _session2.Process.MainWindowTitle; }


### PR DESCRIPTION
## Issues
 - Fixes #
 - Resolves #
 - Closes #

## Description
I have changed the names displayed for the applications.  
I now use the "File Description" property of the process instead of the process name. That should make a lot more sense to the user and matches what you see in the windows mixer.  
i.e: chrome is now Google Chrome, vlc is VLC Media Player.

## Types of changes
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Compiled and tested requested changes
- [X] Updated the documentation, if necessary
- [X] Updated the LICENSES file, if necessary
- [X] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository
- [X] Requesting to **pull a topic/feature/bugfix branch**


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
