### PR TITLE
Adding option to use old or new bootloader

### DIFF
--- a/Desktop/FirmwareInstaller/FirmwareInstaller/MainWindow.xaml
+++ b/Desktop/FirmwareInstaller/FirmwareInstaller/MainWindow.xaml
@@ -14,6 +14,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         
@@ -34,12 +35,18 @@
                   ItemsSource="{Binding Ports}" SelectedValue="{Binding SelectedPort}"
                   IsEnabled="{Binding IsBusy, Converter={StaticResource Cnv_BoolNegate}}"/>
 
+        <!-- Bootloader -->
+        <Label Grid.Column="0" Grid.Row="2" Content="Old bootloader" Margin="0,5,0,0"/>
+        <CheckBox Grid.Column="1" Grid.Row="2" Margin="0,5,15,0"
+                  IsChecked="{Binding UseOldBootloader}"
+                  IsEnabled="{Binding IsBusy, Converter={StaticResource Cnv_BoolNegate}}"/>
+
         <!-- Install -->
-        <Button Grid.Column="1" Grid.Row="2" Content="Install" Margin="0,5,15,0" MinWidth="150" HorizontalAlignment="Right"
+        <Button Grid.Column="1" Grid.Row="3" Content="Install" Margin="0,5,15,0" MinWidth="150" HorizontalAlignment="Right"
                 Command="{Binding InstallCommand}"/>
 
         <!-- Log -->
-        <ScrollViewer x:Name="Ctrl_LogScroll" Grid.ColumnSpan="2" Grid.Row="3" Margin="0,25,0,0">
+        <ScrollViewer x:Name="Ctrl_LogScroll" Grid.ColumnSpan="2" Grid.Row="4" Margin="0,25,0,0">
             <TextBox x:Name="Ctrl_Log" IsReadOnly="True" Text="{Binding Log, Mode=OneWay}" />
         </ScrollViewer>
     </Grid>

--- a/Desktop/FirmwareInstaller/FirmwareInstaller/Services/InstallService.cs
+++ b/Desktop/FirmwareInstaller/FirmwareInstaller/Services/InstallService.cs
@@ -47,14 +47,16 @@ namespace FirmwareInstaller.Services
         /// <param name="filePath">The absolute local file path to the .hex firmware file.</param>
         /// <param name="port">The COM port where the maxmix device is plugged in.</param>
         /// <returns></returns>
-        public Task InstallAsync(string filePath, string port)
+        public Task InstallAsync(string filePath, string port, bool useOldBootloader)
         {
             return Task.Run(() =>
             {
+                var baudRate = useOldBootloader ? "57600" : "115200";
+
                 var processInfo = new ProcessStartInfo
                 {
                     FileName = _exeFilePath,
-                    Arguments = $"-C\"{_configFilePath}\" -v -patmega328p -carduino -P{port} -b57600 -D -U\"flash:w:{filePath}:i\"",
+                    Arguments = $"-C\"{_configFilePath}\" -v -patmega328p -carduino -P{port} -b{baudRate} -D -U\"flash:w:{filePath}:i\"",
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,


### PR DESCRIPTION
## Issues
 - Fixes #58 
 - Resolves #
 - Closes #

## Description
Added an option to the firmware installer to choose between the old and new bootloader.
The only difference as far as uploading the firmware to the device is the baudrate used.

## Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Compiled and tested requested changes
- [X] Updated the documentation, if necessary
- [X] Updated the LICENSES file, if necessary
- [X] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository
- [X] Requesting to **pull a topic/feature/bugfix branch**


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
