### PR TITLE
Adjusted SerialPort configuration to activate RTS and DTS lines for ATmega32U4 based Arduino boards

### DIFF
--- a/Desktop/Application/MaxMix/Services/Communication/CommunicationService.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/CommunicationService.cs
@@ -130,7 +130,8 @@ namespace MaxMix.Services.Communication
                 _serialPort = new SerialPort(portName, baudRate);
                 _serialPort.ReadTimeout = _timeout;
                 _serialPort.WriteTimeout = _timeout;
-
+                _serialPort.DtrEnable = true;
+                _serialPort.RtsEnable = true;
                 _serialPort.Open();
                 _serialPort.DataReceived += OnDataReceived;
             }

--- a/Desktop/Application/MaxMix/Services/Communication/DiscoveryService.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/DiscoveryService.cs
@@ -91,6 +91,8 @@ namespace MaxMix.Services.Communication
                     serialPort = new SerialPort(portName, _baudRate);
                     serialPort.ReadTimeout = _timeout;
                     serialPort.WriteTimeout = _timeout;
+                    serialPort.DtrEnable = true;
+                    serialPort.RtsEnable = true;
                     serialPort.Open();
 
                     Send(serialPort);


### PR DESCRIPTION
## Description
This will solve communication issues with ATmega32U4 based Arduino boards like Sparkfun's Pro Micro and it's clones.

## Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Compiled and tested requested changes
- [ ] Updated the documentation, if necessary
- [ ] Updated the LICENSES file, if necessary
- [ ] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository
- [ ] Requesting to **pull a topic/feature/bugfix branch**


## Further comments

If accepted, this will open the Maxmix plattform to ATmega32U4 based Arduino boards. These do also feature support for other USB device profiles e.g. HID keyboard & multimedia control. So in the future Maxmix could even provide a portable/compatibility mode that offers limited multimedia control on any Computer without the need for drivers or software. More info about the USB HID features: https://github.com/NicoHood/HID
