### PR TITLE
Updated behavior on application change and on wake

### DIFF
--- a/Embedded/MaxMix/MaxMix.ino
+++ b/Embedded/MaxMix/MaxMix.ino
@@ -208,7 +208,10 @@ void ProcessPackage()
 
     // Switch to newly added item.
     if(settings.displayNewSession)
+    {
       itemIndex = index;
+      state = STATE_APPLICATION_NAVIGATE;
+    }
   }
   else if(command == MSG_COMMAND_REMOVE)
   {
@@ -223,6 +226,10 @@ void ProcessPackage()
       return;
       
     RemoveItemCommand(decodeBuffer, items, &itemCount, index);
+
+    // Return to Navigate state if active application is removed
+    if(itemIndex == index)
+      state = STATE_APPLICATION_NAVIGATE;
 
     // Make sure current menu index is not out of bounds after removing item.
     itemIndex = GetNextIndex(itemIndex, itemCount, 0, settings.continuousScroll);
@@ -255,7 +262,7 @@ void ProcessPackage()
   {
     UpdateSettingsCommand(decodeBuffer, &settings);
   }
-}
+} 
 
 //---------------------------------------------------------
 //---------------------------------------------------------

--- a/Embedded/MaxMix/MaxMix.ino
+++ b/Embedded/MaxMix/MaxMix.ino
@@ -210,7 +210,8 @@ void ProcessPackage()
     if(settings.displayNewSession)
     {
       itemIndex = index;
-      state = STATE_APPLICATION_NAVIGATE;
+      if(mode == MODE_APPLICATION)
+        state = STATE_APPLICATION_NAVIGATE;
     }
   }
   else if(command == MSG_COMMAND_REMOVE)
@@ -228,7 +229,7 @@ void ProcessPackage()
     RemoveItemCommand(decodeBuffer, items, &itemCount, index);
 
     // Return to Navigate state if active application is removed
-    if(itemIndex == index)
+    if(itemIndex == index && mode == MODE_APPLICATION)
       state = STATE_APPLICATION_NAVIGATE;
 
     // Make sure current menu index is not out of bounds after removing item.

--- a/Embedded/MaxMix/MaxMix.ino
+++ b/Embedded/MaxMix/MaxMix.ino
@@ -278,7 +278,7 @@ bool ProcessEncoderRotation()
   else if(encoderDir == DIR_CCW)
     encoderDelta = -1;
 
-  if(itemCount == 0)
+  if(itemCount == 0 || screenState == STATE_SCREEN_SLEEP)
     return true;
 
   if(mode == MODE_APPLICATION)
@@ -323,6 +323,9 @@ bool ProcessEncoderButton()
 {
   if(encoderButton.tapped())
   {
+    if(screenState == STATE_SCREEN_SLEEP)
+      return true;
+      
     if(mode == MODE_APPLICATION)
       CycleAppModeState();
     else if(mode == MODE_GAME)
@@ -333,6 +336,9 @@ bool ProcessEncoderButton()
   
   if(encoderButton.doubleTapped())
   {
+    if(screenState == STATE_SCREEN_SLEEP)
+      return true;
+      
     if(mode == MODE_GAME)
       ResetGameModeVolumes();
 
@@ -341,6 +347,9 @@ bool ProcessEncoderButton()
 
   if(encoderButton.held())
   {
+    if(screenState == STATE_SCREEN_SLEEP)
+      return true;
+      
     if(itemCount > 0)
       CycleMode();
       


### PR DESCRIPTION
## Issues
 - Closes #68 , Closes #74

## Description
Changes state to navigate if the active app is closed.
Changes state to navigate when a new app is added (with displayNewSession set)
First input to wake device is discarded.

## Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Requested changes are in a branch
- [X] Compiled and tested requested changes on target hardware (PC, device)
- [ ] Updated the documentation, if necessary
- [ ] Updated the LICENSES file, if necessary
- [X] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository
