### PR TITLE
Improved wake behaviour

### DIFF
--- a/Embedded/MaxMix/Communication.ino
+++ b/Embedded/MaxMix/Communication.ino
@@ -70,10 +70,10 @@ bool DecodePackage(const uint8_t* inBuffer, uint8_t size, uint8_t* outBuffer)
 
 //-----------------------------------------------------------------------------
 // \brief Encode a byte buffer with the COBS encoder.
-// \param buffer A pointer to the unencoded buffer to encode.
-// \param size  The number of bytes in the \p buffer.
-// \param encodedBuffer The buffer for the encoded bytes.
-// \returns The number of bytes written to the \p encodedBuffer.
+// \param inBuffer A pointer to the unencoded buffer to encode.
+// \param size  The number of bytes in the \p inBuffer.
+// \param outBuffer The buffer for the encoded bytes.
+// \returns The number of bytes written to the \p outBuffer.
 // \warning The encodedBuffer must have at least getEncodedBufferSize() 
 //          allocated.
 //-----------------------------------------------------------------------------
@@ -113,10 +113,10 @@ uint8_t Encode(const uint8_t* inBuffer, uint8_t size, uint8_t* outBuffer)
 
 //-----------------------------------------------------------------------------
 // \brief Decode a COBS-encoded buffer.
-// \param encodedBuffer A pointer to the \p encodedBuffer to decode.
-// \param size The number of bytes in the \p encodedBuffer.
-// \param decodedBuffer The target buffer for the decoded bytes.
-// \returns The number of bytes written to the \p decodedBuffer.
+// \param inBuffer A pointer to the \p inBuffer to decode.
+// \param size The number of bytes in the \p inBuffer.
+// \param outBuffer The target buffer for the decoded bytes.
+// \returns The number of bytes written to the \p outBuffer.
 // \warning decodedBuffer must have a minimum capacity of size.
 //-----------------------------------------------------------------------------
 uint8_t Decode(const uint8_t* inBuffer, uint8_t size, uint8_t* outBuffer)


### PR DESCRIPTION
## Issues
 - Resolves #82 

## Description
Reduced screen wakes to only relevant events

## Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Requested changes are in a branch
- [X] Compiled and tested requested changes on target hardware (PC, device)
- [X] Updated the documentation, if necessary
- [ ] Updated the LICENSES file, if necessary
- [X] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository


## Further comments

Not sure if changing the way the command decode is ideal. I did it this way because I need access to the incoming command.
The other option would be to put in the wake-checking code into ProcessPackage, which seems like a worse idea to me. Thoughts?
