### PR TITLE
Fix Session Audio control propagation down to Device level

### DIFF
--- a/Desktop/Application/MaxMix/Services/Audio/AudioDevice.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioDevice.cs
@@ -198,6 +198,15 @@ namespace MaxMix.Services.Audio
                 InitializeSessions();
             }
         }
+
+        public void SetSessionVolume(int id, int volume, bool isMuted)
+        {
+            if (!_sessions.TryGetValue(id, out var session))
+                return;
+
+            session.Volume = volume;
+            session.IsMuted = isMuted;
+        }
         #endregion
 
         #region IDisposable

--- a/Desktop/Application/MaxMix/Services/Audio/AudioSessionService.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioSessionService.cs
@@ -90,7 +90,14 @@ namespace MaxMix.Services.Audio
         public void SetSessionVolume(int id, int volume, bool isMuted)
         {
             if (!_devices.TryGetValue(id, out var session))
+            {
+                foreach (var device in _devices)
+                {
+                    var deviceSession = device.Value as AudioDevice;
+                    deviceSession.SetSessionVolume(id, volume, isMuted);
+                }
                 return;
+            }
 
             session.Volume = volume;
             session.IsMuted = isMuted;


### PR DESCRIPTION
## Issues
 - Fixes #
 - Resolves #
 - Closes #

## Description
Fixes application volume control by propagating set session audio function down to device level

## Types of changes
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Requested changes are in a branch
- [x] Compiled and tested requested changes on target hardware (PC, device)
- [ ] Updated the documentation, if necessary
- [ ] Updated the LICENSES file, if necessary
- [x] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
