### PR TITLE
Added function get safely return Product Name as a fallback

### DIFF
--- a/Desktop/Application/MaxMix/Services/Audio/AudioExtensions.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioExtensions.cs
@@ -25,5 +25,13 @@ namespace MaxMix.Services.Audio
             IntPtr handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE, false, process.Id);
             return QueryFullProcessImageName(handle, 0, fileNameBuilder, ref bufferLength) ? fileNameBuilder.ToString() : null;
         }
+
+        public static string GetProductName(this Process process)
+        {
+            string fileName = process.GetMainModuleFileName();
+            if (string.IsNullOrEmpty(fileName)) return null;
+            var versionInfo = FileVersionInfo.GetVersionInfo(fileName);
+            return versionInfo.ProductName;
+        }
     }
 }

--- a/Desktop/Application/MaxMix/Services/Audio/AudioSession.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioSession.cs
@@ -99,6 +99,7 @@ namespace MaxMix.Services.Audio
             var displayName = _session2.DisplayName;
             if (IsSystemSound) { displayName = "System Sounds"; }
             if (string.IsNullOrEmpty(displayName)) { displayName = _session2.Process.MainWindowTitle; }
+            if (string.IsNullOrEmpty(displayName)) { displayName = _session2.Process.GetProductName(); }
             if (string.IsNullOrEmpty(displayName)) { displayName = _session2.Process.ProcessName; }
             if (string.IsNullOrEmpty(displayName)) { displayName = "Unnamed"; }
             displayName = char.ToUpper(displayName[0]) + displayName.Substring(1);


### PR DESCRIPTION
## Issues
 - Resolves #86

## Description
Stumbled upon the value being used as a fallback. It's the FileVersionInfo's Product Name being used if the MainWindowTitle is null or empty. This should now mirror the exact results as the default Windows Volume Mixer 

## Types of changes
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Requested changes are in a branch
- [x] Compiled and tested requested changes on target hardware (PC, device)
- [ ] Updated the documentation, if necessary
- [ ] Updated the LICENSES file, if necessary
- [x] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
