### PR TITLE
Fix volume changed event feedback

### DIFF
--- a/Desktop/Application/MaxMix/Services/Audio/AudioDevice.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioDevice.cs
@@ -71,7 +71,6 @@ namespace MaxMix.Services.Audio
 
                 _isNotifyEnabled = false;
                 _endpointVolume.MasterVolumeLevelScalar = value / 100f;
-                _isNotifyEnabled = true;
             }
         }
 
@@ -86,7 +85,6 @@ namespace MaxMix.Services.Audio
 
                 _isNotifyEnabled = false;
                 _endpointVolume.IsMuted = value;
-                _isNotifyEnabled = true;
             }
         }
         #endregion
@@ -193,7 +191,10 @@ namespace MaxMix.Services.Audio
         private void OnEndpointVolumeChanged(object sender, AudioEndpointVolumeCallbackEventArgs e)
         {
             if (!_isNotifyEnabled)
+            {
+                _isNotifyEnabled = true;
                 return;
+            }
 
             VolumeChanged?.Invoke(this);
         }

--- a/Desktop/Application/MaxMix/Services/Audio/AudioSession.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioSession.cs
@@ -73,7 +73,6 @@ namespace MaxMix.Services.Audio
 
                 _isNotifyEnabled = false;
                 _simpleAudio.MasterVolume = value / 100f;
-                _isNotifyEnabled = true;
             }
         }
 
@@ -88,7 +87,6 @@ namespace MaxMix.Services.Audio
 
                 _isNotifyEnabled = false;
                 _simpleAudio.IsMuted = value;
-                _isNotifyEnabled = true;
             }
         }
         #endregion
@@ -112,7 +110,10 @@ namespace MaxMix.Services.Audio
         private void OnVolumeChanged(object sender, AudioSessionSimpleVolumeChangedEventArgs e)
         {
             if (!_isNotifyEnabled)
+            {
+                _isNotifyEnabled = true;
                 return;
+            }
 
             VolumeChanged?.Invoke(this);
         }

--- a/Desktop/Application/MaxMix/Services/Audio/AudioSessionGroup.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioSessionGroup.cs
@@ -91,7 +91,6 @@ namespace MaxMix.Services.Audio
             _volume = value;
             foreach (var session in _sessions.Values)
                 session.Volume = value;
-            _isNotifyEnabled = true;
         }
 
         private void SetIsMuted(bool value)
@@ -103,7 +102,6 @@ namespace MaxMix.Services.Audio
             _isMuted = value;
             foreach (var session in _sessions.Values)
                 session.IsMuted = value;
-            _isNotifyEnabled = true;
         }
         #endregion
 
@@ -114,7 +112,10 @@ namespace MaxMix.Services.Audio
             _isMuted = session.IsMuted;
 
             if (!_isNotifyEnabled)
+            {
+                _isNotifyEnabled = true;
                 return;
+            }
 
             VolumeChanged?.Invoke(this);
         }


### PR DESCRIPTION
## Issues

## Description
The setter of the volume property of the Session classes was not disabling notifications when setting the value. That was causing the changed event to be raised and the a message being sent to the device when the change was initiated by the device.

## Types of changes
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Requested changes are in a branch
- [X] Compiled and tested requested changes on target hardware (PC, device)
- [X] Updated the documentation, if necessary
- [X] Updated the LICENSES file, if necessary
- [X] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
