### PR TITLE
Updating sleepAfterSeconds default to 5

### DIFF
--- a/Desktop/Application/MaxMix/App.config
+++ b/Desktop/Application/MaxMix/App.config
@@ -17,7 +17,7 @@
                 <value>True</value>
             </setting>
             <setting name="SleepAfterSeconds" serializeAs="String">
-                <value>15</value>
+                <value>5</value>
             </setting>
             <setting name="ContinuousScroll" serializeAs="String">
                 <value>True</value>

--- a/Desktop/Application/MaxMix/Properties/Settings.Designer.cs
+++ b/Desktop/Application/MaxMix/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace MaxMix.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.5.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -49,7 +49,7 @@ namespace MaxMix.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("15")]
+        [global::System.Configuration.DefaultSettingValueAttribute("5")]
         public int SleepAfterSeconds {
             get {
                 return ((int)(this["SleepAfterSeconds"]));

--- a/Desktop/Application/MaxMix/Properties/Settings.settings
+++ b/Desktop/Application/MaxMix/Properties/Settings.settings
@@ -9,7 +9,7 @@
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="SleepAfterSeconds" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">15</Value>
+      <Value Profile="(Default)">5</Value>
     </Setting>
     <Setting Name="ContinuousScroll" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>


### PR DESCRIPTION
## Issues

## Description
Updates default sleepAfterSeconds to 5 to extend OLED life.

## Types of changes
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Requested changes are in a branch
- [X] Compiled and tested requested changes on target hardware (PC, device)
- [X] Updated the documentation, if necessary
- [X] Updated the LICENSES file, if necessary
- [X] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
