### PR TITLE
Check for null endPointVolume

### DIFF
--- a/Desktop/Application/MaxMix/Services/Audio/AudioDevice.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioDevice.cs
@@ -48,6 +48,9 @@ namespace MaxMix.Services.Audio
         private IDictionary<int, IAudioSession> _sessions = new ConcurrentDictionary<int, IAudioSession>();
         private bool _visibleSystemSounds = false;
         private bool _isNotifyEnabled = true;
+        
+        private int _volume;
+        private bool _isMuted;
         #endregion
 
         #region Properties
@@ -63,13 +66,20 @@ namespace MaxMix.Services.Audio
         /// <inheritdoc/>
         public int Volume
         {
-            get => (int)Math.Round(_endpointVolume.MasterVolumeLevelScalar * 100);
+            get
+            {
+                try { _volume = (int)Math.Round(_endpointVolume.MasterVolumeLevelScalar * 100); }
+                catch { }
+
+                return _volume;
+            }
             set
             {
-                if (Volume == value)
+                if (_volume == value)
                     return;
 
                 _isNotifyEnabled = false;
+                _volume = value;
                 _endpointVolume.MasterVolumeLevelScalar = value / 100f;
             }
         }
@@ -77,13 +87,20 @@ namespace MaxMix.Services.Audio
         /// <inheritdoc/>
         public bool IsMuted
         {
-            get => _endpointVolume.IsMuted;
+            get
+            {
+                try { _isMuted = _endpointVolume.IsMuted; }
+                catch { }
+
+                return _isMuted;
+            }
             set
             {
-                if (IsMuted == value)
+                if (_isMuted == value)
                     return;
 
                 _isNotifyEnabled = false;
+                _isMuted = value;
                 _endpointVolume.IsMuted = value;
             }
         }


### PR DESCRIPTION
## Issues
 - Potentially fixes #107 

## Description
As reported in #107 the AudioEndpointVolume instance sometimes returns null.
Based on user information, it seems like a hiccup, not that the object is disposed and we need to retrieve it again.
Adding a try/catch block when accessing it to avoid this.

## Types of changes
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Requested changes are in a branch
- [x] Compiled and tested requested changes on target hardware (PC, device)
- [x] Updated the documentation, if necessary
- [x] Updated the LICENSES file, if necessary
- [x] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
