### PR TITLE
Fix crash occuring ocassionaly in set/get simple audio

### DIFF
--- a/Desktop/Application/MaxMix/Services/Audio/AudioSession.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioSession.cs
@@ -40,6 +40,9 @@ namespace MaxMix.Services.Audio
         private AudioSessionControl2 _session2;
         private SimpleAudioVolume _simpleAudio;
         private bool _isNotifyEnabled = true;
+
+        private int _volume;
+        private bool _isMuted;
         #endregion
 
         #region Properties
@@ -65,28 +68,44 @@ namespace MaxMix.Services.Audio
         /// <inheritdoc/>
         public int Volume
         {
-            get => (int)Math.Round(_simpleAudio.MasterVolume * 100);
+            get
+            {
+                try { _volume = (int)Math.Round(_simpleAudio.MasterVolume * 100); }
+                catch { }
+
+                return _volume;
+            }
             set
             {
-                if (Volume == value)
+                if (_volume == value)
                     return;
 
                 _isNotifyEnabled = false;
-                _simpleAudio.MasterVolume = value / 100f;
+                _volume = value;
+                try { _simpleAudio.MasterVolume = value / 100f; }
+                catch { }
             }
         }
 
         /// <inheritdoc/>
         public bool IsMuted
         {
-            get => _simpleAudio.IsMuted;
+            get
+            {
+                try { _isMuted = _simpleAudio.IsMuted; }
+                catch { }
+
+                return _isMuted;
+            }
             set
             {
-                if (IsMuted == value)
+                if (_isMuted == value)
                     return;
 
                 _isNotifyEnabled = false;
-                _simpleAudio.IsMuted = value;
+                _isMuted = value;
+                try { _simpleAudio.IsMuted = value; }
+                catch { }
             }
         }
         #endregion


### PR DESCRIPTION
## Issues
 - Fixes: #MAXMIX-J, #MAXMIX-H

## Description
Fixes crashes reported in Sentry accessing simpleVolume in AudioSession.cs.
Adds exception handling same way we did for AudioDevice.

## Types of changes
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Requested changes are in a branch
- [X] Compiled and tested requested changes on target hardware (PC, device)
- [X] Updated the documentation, if necessary
- [X] Updated the LICENSES file, if necessary
- [X] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
