### PR TITLE
Reseting state after receiving a handshake

### DIFF
--- a/Embedded/MaxMix/MaxMix.ino
+++ b/Embedded/MaxMix/MaxMix.ino
@@ -71,7 +71,7 @@ uint8_t isDirty = true;
 
 struct Item items[ITEM_MAX_COUNT];
 int8_t itemIndexMaster = 0;
-int8_t itemIndexApp = -1;
+int8_t itemIndexApp = 0;
 int8_t itemIndexGameA = 0;
 int8_t itemIndexGameB = 0;
 uint8_t itemCount = 0;
@@ -189,6 +189,24 @@ void ClearSend()
 }
 
 //---------------------------------------------------------
+//---------------------------------------------------------
+void ResetState()
+{
+  mode = MODE_MASTER;
+  stateApplication = STATE_APPLICATION_NAVIGATE;
+  stateGame = STATE_GAME_SELECT_A;
+  stateDisplay = STATE_DISPLAY_AWAKE;
+  //isDirty = true;
+
+  itemIndexMaster = 0;
+  itemIndexApp = 0;
+  itemIndexGameA = 0;
+  itemIndexGameB = 0;
+  itemCount = 0;
+}
+
+
+//---------------------------------------------------------
 // \brief Handles incoming commands.
 // \returns true if screen update is required.
 //---------------------------------------------------------
@@ -198,7 +216,10 @@ bool ProcessPackage()
   
   if(command == MSG_COMMAND_HS_REQUEST)
   {
+    ResetState();
     SendHandshakeCommand(sendBuffer, encodeBuffer);
+
+    return true;
   }
   else if(command == MSG_COMMAND_ADD)
   {


### PR DESCRIPTION
## Issues
 - Resolves #127

## Description
Added a function that resets all state variables to their defaults after receiving a handshake package.
That way every time the device connects to the application for whatever reason, it starts fresh.

## Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Requested changes are in a branch
- [X] Compiled and tested requested changes on target hardware (PC, device)
- [X] Updated the documentation, if necessary
- [X] Updated the LICENSES file, if necessary
- [X] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
