### PR TITLE
Optimized volume acceleration calculation with fixed points maths

### DIFF
--- a/Embedded/MaxMix/MaxMix.ino
+++ b/Embedded/MaxMix/MaxMix.ino
@@ -29,6 +29,8 @@
 #include "src/ButtonEvents/ButtonEvents.h"
 #include "src/Rotary/Rotary.h"
 #include "src/TimerOne/TimerOne.h"
+#include "src/FixedPoints/FixedPoints.h"
+#include "src/FixedPoints/FixedPointsCommon.h"
 
 //********************************************************
 // *** STRUCTS
@@ -313,14 +315,22 @@ int8_t ComputeAcceleratedVolume(int8_t encoderDelta, uint32_t deltaTime, int16_t
   if (!encoderDelta)
     return volume;
 
-  float speed = (float)encoderDelta*1000/deltaTime;
-  float accelerationDivisor = max((1-(float)settings.accelerationPercentage/100)*ROTARY_ACCELERATION_DIVISOR_MAX, 1);
-  uint32_t step = 1 + abs(speed*speed/accelerationDivisor);
+  bool dirChanged = ((prevDir > 0) && (encoderDelta < 0)) || ((prevDir < 0) && (encoderDelta > 0));
 
-  // Direction change detection
-  if((prevDir > 0 && encoderDelta < 0)||(prevDir < 0 && encoderDelta > 0)){
-    step = 1;
+  uint32_t step;
+  if (dirChanged)
+  {
+     step = 1;
   }
+  else
+  {
+    // Compute acceleration using fixed point maths.
+    SQ15x16 speed = (SQ15x16)encoderDelta*1000/deltaTime;
+    SQ15x16 accelerationDivisor = max((1-(SQ15x16)settings.accelerationPercentage/100)*ROTARY_ACCELERATION_DIVISOR_MAX, 1);
+    SQ15x16 fstep = 1 + absFixed(speed*speed/accelerationDivisor);
+    step = fstep.getInteger();
+  }
+
   prevDir = encoderDelta;
 
   if(encoderDelta > 0)
@@ -332,8 +342,7 @@ int8_t ComputeAcceleratedVolume(int8_t encoderDelta, uint32_t deltaTime, int16_t
     volume -= step;
   }
   
-  volume = constrain(volume, 0, 100);
-  return volume;
+  return constrain(volume, 0, 100);
 }
 
 //---------------------------------------------------------

--- a/Embedded/MaxMix/src/FixedPoints/FixedPoints.h
+++ b/Embedded/MaxMix/src/FixedPoints/FixedPoints.h
@@ -1,0 +1,15 @@
+// Copyright 2017-2018 Pharap
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "FixedPoints/FixedPoints.h"

--- a/Embedded/MaxMix/src/FixedPoints/FixedPoints/Details.h
+++ b/Embedded/MaxMix/src/FixedPoints/FixedPoints/Details.h
@@ -1,0 +1,205 @@
+// Copyright 2017-2018 Pharap
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Arduino.h>
+#include <limits.h>
+#include <stdint.h>
+
+#if defined(FIXED_POINTS_USE_NAMESPACE)
+#define FIXED_POINTS_NAMESPACE FixedPoints
+#define FIXED_POINTS_BEGIN_NAMESPACE namespace FIXED_POINTS_NAMESPACE\
+{
+#define FIXED_POINTS_END_NAMESPACE }
+#define FIXED_POINTS_DETAILS Details
+#else
+#define FIXED_POINTS_NAMESPACE
+#define FIXED_POINTS_BEGIN_NAMESPACE
+#define FIXED_POINTS_END_NAMESPACE
+#define FIXED_POINTS_DETAILS FixedPointsDetails
+#endif
+
+#if defined(ESP8266) || defined(ARDUINO_SAM_DUE)
+#define FIXED_POINTS_NO_RANDOM
+#endif
+
+// Pay no attention to the man behind the curtains
+
+FIXED_POINTS_BEGIN_NAMESPACE
+namespace FIXED_POINTS_DETAILS
+{
+	template< typename T >
+	struct BitSize
+	{
+		BitSize() = delete;
+		static constexpr auto Value = sizeof(T) * CHAR_BIT;
+	};
+
+	template< bool Condition, typename TTrue, typename TFalse >
+	struct Conditional;
+
+	template< typename TTrue, typename TFalse >
+	struct Conditional< true, TTrue, TFalse > { using Type = TTrue; };
+
+	template< typename TTrue, typename TFalse >
+	struct Conditional< false, TTrue, TFalse > { using Type = TFalse; };
+	
+	template< bool Condition, typename TTrue, typename TFalse >
+	using ConditionalT = typename Conditional<Condition, TTrue, TFalse >::Type;
+
+	template< typename T, typename U >
+	using LargerType = ConditionalT<(BitSize<T>::Value > BitSize<U>::Value), T, U>;
+
+	template< typename T, typename U >
+	using StrictLargerType = ConditionalT< (BitSize<T>::Value > BitSize<U>::Value), T, ConditionalT< (BitSize<U>::Value > BitSize<T>::Value), U, void > >;
+
+	template< typename T, typename U >
+	using SmallerType = ConditionalT<(BitSize<T>::Value < BitSize<U>::Value), T, U>;
+
+	template< typename T, typename U >
+	using StrictSmallerType = ConditionalT< (BitSize<T>::Value < BitSize<U>::Value), T, ConditionalT< (BitSize<U>::Value < BitSize<T>::Value), U, void > >;
+
+	template< unsigned Bits, typename... Ts >
+	struct LeastTypeHelper;
+
+	template< unsigned Bits, typename T, typename... Ts >
+	struct LeastTypeHelper<Bits, T, Ts... >
+	{
+		LeastTypeHelper() = delete;
+		using Type = ConditionalT<(Bits <= BitSize<T>::Value), T, typename LeastTypeHelper<Bits, Ts...>::Type>;
+	};
+
+	template< unsigned Bits >
+	struct LeastTypeHelper<Bits>
+	{
+		LeastTypeHelper() = delete;
+		using Type = void;
+	};
+
+
+	template< unsigned Bits, typename... Ts >
+	using LeastType = typename LeastTypeHelper<Bits, Ts...>::Type;
+
+	template< unsigned Bits >
+	struct LeastUIntDef
+	{
+		static_assert(Bits <= BitSize<uintmax_t>::Value, "No type large enough");
+		LeastUIntDef() = delete;
+		using Type = LeastType<Bits, uint_least8_t, uint_least16_t, uint_least32_t, uint_least64_t, uintmax_t>;
+	};
+	
+
+	template< unsigned Bits >
+	using LeastUInt = typename LeastUIntDef<Bits>::Type;
+
+	template< unsigned Bits >
+	struct LeastIntDef
+	{
+		static_assert(Bits <= BitSize<intmax_t>::Value, "No type large enough");
+		LeastIntDef() = delete;
+		using Type = LeastType<Bits, int_least8_t, int_least16_t, int_least32_t, int_least64_t, intmax_t>;
+	};
+
+	template< unsigned Bits >
+	using LeastInt = typename LeastIntDef<Bits>::Type;
+
+	template< unsigned Bits >
+	struct MsbMask
+	{
+		MsbMask() = delete;
+		static constexpr LeastUInt<Bits> Value = (1ull << (Bits - 1));
+	};
+
+	template< unsigned Bits >
+	struct IdentityMask
+	{
+		IdentityMask() = delete;
+		static constexpr LeastUInt<Bits> Value = 1 | (IdentityMask<Bits - 1>::Value << 1);
+	};
+
+	template<>
+	struct IdentityMask<0>
+	{
+		IdentityMask() = delete;
+		static constexpr LeastUInt<0> Value = 0;
+	};
+	
+#if !defined(FIXED_POINTS_NO_RANDOM)
+	template< typename T >
+	struct RandomHelper;
+	
+	template<>
+	struct RandomHelper<uint8_t>
+	{
+		static inline uint8_t Random() { return static_cast<uint8_t>(random()); }
+	};
+	
+	template<>
+	struct RandomHelper<uint16_t>
+	{
+		static inline uint16_t Random() { return static_cast<uint16_t>(random()); }
+	};
+	
+	template<>
+	struct RandomHelper<uint32_t>
+	{
+		static inline uint32_t Random() { return static_cast<uint32_t>(random()); }
+	};
+	
+	template<>
+	struct RandomHelper<uint64_t>
+	{
+		static inline uint64_t Random() { return (static_cast<uint64_t>(random()) << 32) | static_cast<uint64_t>(random()); }
+	};
+	
+	template<>
+	struct RandomHelper<int8_t>
+	{
+		static inline int8_t Random() { return static_cast<int8_t>(random()); }
+	};
+	
+	template<>
+	struct RandomHelper<int16_t>
+	{
+		static inline int16_t Random() { return static_cast<int16_t>(random()); }
+	};
+	
+	template<>
+	struct RandomHelper<int32_t>
+	{
+		static inline int32_t Random() { return static_cast<int32_t>(random()); }
+	};
+	
+	template<>
+	struct RandomHelper<int64_t>
+	{
+		static inline int64_t Random() { return (static_cast<int64_t>(random()) << 32) | static_cast<int64_t>(random()); }
+	};
+#endif
+
+	///////////////////////
+	// Here be dragons!! //
+	//                   //
+	//     /\___/\  _    //
+	//    ( O . O ) \\   //
+	//     >  ^  <  //   //
+	//    ( \   / )//    //
+	//     u U U u       //
+	//                   //
+	//    Or cats?...    //
+	//     ~Mwrow~       //
+	///////////////////////
+}
+FIXED_POINTS_END_NAMESPACE

--- a/Embedded/MaxMix/src/FixedPoints/FixedPoints/FixedPoints.h
+++ b/Embedded/MaxMix/src/FixedPoints/FixedPoints/FixedPoints.h
@@ -1,0 +1,20 @@
+// Copyright 2017-2018 Pharap
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Details.h"
+
+#include "UFixed.h"
+#include "SFixed.h"
+
+#include "Utils.h"

--- a/Embedded/MaxMix/src/FixedPoints/FixedPoints/SFixed.h
+++ b/Embedded/MaxMix/src/FixedPoints/FixedPoints/SFixed.h
@@ -1,0 +1,219 @@
+// Copyright 2017-2018 Pharap
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "Details.h"
+
+FIXED_POINTS_BEGIN_NAMESPACE
+
+//
+// Declaration
+//
+
+template< unsigned Integer, unsigned Fraction >
+class SFixed
+{
+public:
+	static constexpr uintmax_t IntegerSize = Integer + 1;
+	static constexpr uintmax_t FractionSize = Fraction;
+	static constexpr uintmax_t LogicalSize = IntegerSize + FractionSize;
+	static constexpr uintmax_t Scale = UINTMAX_C(1) << FractionSize;
+
+public:
+	static_assert(LogicalSize <= FIXED_POINTS_DETAILS::BitSize<intmax_t>::Value, "Platform does not have a native type large enough for SFixed.");
+
+public:
+	using IntegerType = FIXED_POINTS_DETAILS::LeastInt<IntegerSize>;
+	using FractionType = FIXED_POINTS_DETAILS::LeastUInt<FractionSize>;
+	using InternalType = FIXED_POINTS_DETAILS::LeastInt<LogicalSize>;
+
+	static constexpr uintmax_t InternalSize = FIXED_POINTS_DETAILS::BitSize<InternalType>::Value;
+	
+	using ShiftType = FIXED_POINTS_DETAILS::LeastUInt<LogicalSize>;
+	using MaskType = FIXED_POINTS_DETAILS::LeastUInt<LogicalSize>;
+		
+public:
+	static constexpr ShiftType IntegerShift = FractionSize;
+	static constexpr ShiftType FractionShift = 0;
+	
+	static constexpr MaskType IntegerMask = FIXED_POINTS_DETAILS::IdentityMask<IntegerSize>::Value;
+	static constexpr MaskType FractionMask = FIXED_POINTS_DETAILS::IdentityMask<FractionSize>::Value;
+	
+	static constexpr MaskType IdentityMask = (IntegerMask << IntegerShift) | (FractionMask << FractionShift);
+	
+	static constexpr MaskType MidpointMask = FIXED_POINTS_DETAILS::MsbMask<FractionSize>::Value;
+	static constexpr MaskType LesserMidpointMask = MidpointMask - 1;
+
+protected:
+	class RawType
+	{
+	private:
+		const InternalType value;
+
+	public:
+		constexpr inline explicit RawType(const InternalType & value) : value(value) {}
+		constexpr inline explicit operator InternalType() const { return this->value; }
+	};
+
+protected:
+	InternalType value;
+
+protected:
+	constexpr SFixed(const RawType & value);
+
+public:
+	constexpr SFixed();
+	constexpr SFixed(const IntegerType & integer, const FractionType & fraction);
+	constexpr SFixed(const char & value);
+	constexpr SFixed(const unsigned char & value);
+	constexpr SFixed(const signed char & value);
+	constexpr SFixed(const unsigned short int & value);
+	constexpr SFixed(const signed short int & value);
+	constexpr SFixed(const unsigned int & value);
+	constexpr SFixed(const signed int & value);
+	constexpr SFixed(const unsigned long int & value);
+	constexpr SFixed(const signed long int & value);
+	constexpr SFixed(const unsigned long long int & value);
+	constexpr SFixed(const signed long long int & value);
+	constexpr SFixed(const double & value);
+	constexpr SFixed(const float & value);
+	constexpr SFixed(const long double & value);
+
+	constexpr InternalType getInternal() const;
+	constexpr IntegerType getInteger() const;
+	constexpr FractionType getFraction() const;
+
+	constexpr explicit operator IntegerType() const;
+	constexpr explicit operator float() const;
+	constexpr explicit operator double() const;
+	constexpr explicit operator long double() const;
+
+	template< unsigned IntegerOut, unsigned FractionOut >
+	constexpr explicit operator SFixed<IntegerOut, FractionOut>() const;
+
+	static constexpr SFixed fromInternal(const InternalType & value);
+
+	constexpr SFixed operator -() const;
+	SFixed & operator ++();
+	SFixed & operator --();
+	SFixed & operator +=(const SFixed & other);
+	SFixed & operator -=(const SFixed & other);
+	SFixed & operator *=(const SFixed & other);
+	SFixed & operator /=(const SFixed & other);
+	
+public:
+	static constexpr SFixed Epsilon = SFixed::fromInternal(1);
+	static constexpr SFixed MinValue = SFixed::fromInternal(FIXED_POINTS_DETAILS::MsbMask<InternalSize>::Value);
+	static constexpr SFixed MaxValue = SFixed::fromInternal(~FIXED_POINTS_DETAILS::MsbMask<InternalSize>::Value);
+	
+	// 40 digits is probably enough for these
+	static constexpr SFixed Pi = 3.1415926535897932384626433832795028841971;
+	static constexpr SFixed E = 2.718281828459045235360287471352662497757;
+	static constexpr SFixed Phi = 1.6180339887498948482045868343656381177203;
+	static constexpr SFixed Tau = 6.2831853071795864769252867665590057683943;
+};
+
+
+//
+// Free functions
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer * 2, Fraction * 2> multiply(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right);
+
+//
+// Basic Logic Operations
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator ==(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator !=(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator <(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator >(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator <=(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator >=(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right);
+
+//
+// Inter-size Logic Operations
+//
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator ==(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right);
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator !=(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right);
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator <(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right);
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator >(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right);
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator <=(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right);
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator >=(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right);
+
+//
+// Basic Arithmetic Operations
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> operator +(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> operator -(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> operator *(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> operator /(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right);
+
+//
+// Inter-size Arithmetic Operations
+//
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr auto operator +(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right)
+	-> FIXED_POINTS_DETAILS::LargerType< SFixed<IntegerLeft, FractionLeft>, SFixed<IntegerRight, FractionRight> >;
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr auto operator -(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right)
+	-> FIXED_POINTS_DETAILS::LargerType< SFixed<IntegerLeft, FractionLeft>, SFixed<IntegerRight, FractionRight> >;
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr auto operator *(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right)
+	-> FIXED_POINTS_DETAILS::LargerType< SFixed<IntegerLeft, FractionLeft>, SFixed<IntegerRight, FractionRight> >;
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+inline constexpr auto operator /(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right)
+	-> FIXED_POINTS_DETAILS::LargerType< SFixed<IntegerLeft, FractionLeft>, SFixed<IntegerRight, FractionRight> >;
+	
+FIXED_POINTS_END_NAMESPACE
+
+#include "SFixedMemberFunctions.h"
+#include "SFixedFreeFunctions.h"

--- a/Embedded/MaxMix/src/FixedPoints/FixedPoints/SFixedFreeFunctions.h
+++ b/Embedded/MaxMix/src/FixedPoints/FixedPoints/SFixedFreeFunctions.h
@@ -1,0 +1,323 @@
+// Copyright 2017-2018 Pharap
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+FIXED_POINTS_BEGIN_NAMESPACE
+
+//
+// multiply
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer * 2, Fraction * 2> multiply(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right)
+{
+	static_assert(((Integer + 1) * 2 + Fraction * 2) <= FIXED_POINTS_DETAILS::BitSize<intmax_t>::Value, "Multiplication cannot be performed, the result type would be too large");	
+
+	using ResultType = SFixed<Integer * 2, Fraction * 2>;
+	using InternalType = typename ResultType::InternalType;
+	return ResultType::fromInternal(static_cast<InternalType>(static_cast<InternalType>(left.getInternal()) * static_cast<InternalType>(right.getInternal())));
+}
+
+//
+// Basic Logic Operations
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator ==(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right)
+{
+	return (left.getInternal() == right.getInternal());
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator !=(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right)
+{
+	return (left.getInternal() != right.getInternal());
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator <(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right)
+{
+	return (left.getInternal() < right.getInternal());
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator >(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right)
+{
+	return (left.getInternal() > right.getInternal());
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator <=(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right)
+{
+	return (left.getInternal() <= right.getInternal());
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator >=(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right)
+{
+	return (left.getInternal() >= right.getInternal());
+}
+
+//
+// Inter-size Logic Operations
+//
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator ==(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right)
+{
+	using LeftType = SFixed<IntegerLeft, FractionLeft>;
+	using RightType = SFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator == has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) == static_cast<CompareType>(right));
+}
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator !=(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right)
+{
+	using LeftType = SFixed<IntegerLeft, FractionLeft>;
+	using RightType = SFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator != has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) != static_cast<CompareType>(right));
+}
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator <(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right)
+{
+	using LeftType = SFixed<IntegerLeft, FractionLeft>;
+	using RightType = SFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator < has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) < static_cast<CompareType>(right));
+}
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator >(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right)
+{
+	using LeftType = SFixed<IntegerLeft, FractionLeft>;
+	using RightType = SFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator > has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) > static_cast<CompareType>(right));
+}
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator <=(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right)
+{
+	using LeftType = SFixed<IntegerLeft, FractionLeft>;
+	using RightType = SFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator <= has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) <= static_cast<CompareType>(right));
+}
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator >=(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right)
+{
+	using LeftType = SFixed<IntegerLeft, FractionLeft>;
+	using RightType = SFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator >= has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) >= static_cast<CompareType>(right));
+}
+
+//
+// Basic Arithmetic Operations
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> operator +(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right)
+{
+	using InternalType = typename SFixed<Integer, Fraction>::InternalType;
+	return SFixed<Integer, Fraction>::fromInternal(static_cast<InternalType>(left.getInternal() + right.getInternal()));
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> operator -(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right)
+{
+	using InternalType = typename SFixed<Integer, Fraction>::InternalType;
+	return SFixed<Integer, Fraction>::fromInternal(static_cast<InternalType>(left.getInternal() - right.getInternal()));
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> operator *(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right)
+{
+	static_assert(((Integer + 1) * 2 + Fraction * 2) <= FIXED_POINTS_DETAILS::BitSize<intmax_t>::Value, "Multiplication cannot be performed, the intermediary type would be too large");	
+	
+	using InternalType = typename SFixed<Integer, Fraction>::InternalType;
+	using PrecisionType = typename SFixed<Integer * 2, Fraction * 2>::InternalType;
+	return SFixed<Integer, Fraction>::fromInternal(static_cast<InternalType>((static_cast<PrecisionType>(left.getInternal()) * static_cast<PrecisionType>(right.getInternal())) >> Fraction));
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> operator /(const SFixed<Integer, Fraction> & left, const SFixed<Integer, Fraction> & right)
+{
+	using InternalType = typename SFixed<Integer, Fraction>::InternalType;
+	using PrecisionType = typename SFixed<Integer * 2, Fraction * 2>::InternalType;
+	return SFixed<Integer, Fraction>::fromInternal(static_cast<InternalType>((static_cast<PrecisionType>(left.getInternal()) << Fraction) / right.getInternal()));
+}
+
+//
+// Inter-size Arithmetic Operations
+//
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr auto operator +(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right)
+	-> FIXED_POINTS_DETAILS::LargerType< SFixed<IntegerLeft, FractionLeft>, SFixed<IntegerRight, FractionRight> >
+{
+	using LeftType = SFixed<IntegerLeft, FractionLeft>;
+	using RightType = SFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator + has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) + static_cast<CompareType>(right));
+}
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr auto operator -(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right)
+	-> FIXED_POINTS_DETAILS::LargerType< SFixed<IntegerLeft, FractionLeft>, SFixed<IntegerRight, FractionRight> >
+{
+	using LeftType = SFixed<IntegerLeft, FractionLeft>;
+	using RightType = SFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator - has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) - static_cast<CompareType>(right));
+}
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr auto operator *(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right)
+	-> FIXED_POINTS_DETAILS::LargerType< SFixed<IntegerLeft, FractionLeft>, SFixed<IntegerRight, FractionRight> >
+{
+	using LeftType = SFixed<IntegerLeft, FractionLeft>;
+	using RightType = SFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator * has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) * static_cast<CompareType>(right));
+}
+
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr auto operator /(const SFixed<IntegerLeft, FractionLeft> & left, const SFixed<IntegerRight, FractionRight> & right)
+	-> FIXED_POINTS_DETAILS::LargerType< SFixed<IntegerLeft, FractionLeft>, SFixed<IntegerRight, FractionRight> >
+{
+	using LeftType = SFixed<IntegerLeft, FractionLeft>;
+	using RightType = SFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator / has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) / static_cast<CompareType>(right));
+}
+
+//
+// Literal-type Operators
+// Generated by macro to make maintenance easier
+//
+
+#define LOGIC_OPERATOR( type, op )\
+	template< unsigned Integer, unsigned Fraction >\
+	constexpr bool operator op (const SFixed<Integer, Fraction> & left, const type & right)\
+	{\
+		return (left op SFixed<Integer, Fraction>(right));\
+	}\
+	\
+	template< unsigned Integer, unsigned Fraction >\
+	constexpr bool operator op (const type & left, const SFixed<Integer, Fraction> & right)\
+	{\
+		return (SFixed<Integer, Fraction>(left) op right);\
+	}
+
+#define ARITHMETIC_OPERATOR( type, op )\
+	template< unsigned Integer, unsigned Fraction >\
+	constexpr SFixed<Integer, Fraction> operator op (const SFixed<Integer, Fraction> & left, const type & right)\
+	{\
+		return (left op SFixed<Integer, Fraction>(right));\
+	}\
+	\
+	template< unsigned Integer, unsigned Fraction >\
+	constexpr SFixed<Integer, Fraction> operator op (const type & left, const SFixed<Integer, Fraction> & right)\
+	{\
+		return (SFixed<Integer, Fraction>(left) op right);\
+	}
+	
+#define LOGIC_OPERATORS( type )\
+	LOGIC_OPERATOR( type, == )\
+	LOGIC_OPERATOR( type, != )\
+	LOGIC_OPERATOR( type, < )\
+	LOGIC_OPERATOR( type, <= )\
+	LOGIC_OPERATOR( type, > )\
+	LOGIC_OPERATOR( type, >= )
+			
+#define ARITHMETIC_OPERATORS( type ) \
+	ARITHMETIC_OPERATOR( type, + )\
+	ARITHMETIC_OPERATOR( type, - )\
+	ARITHMETIC_OPERATOR( type, * )\
+	ARITHMETIC_OPERATOR( type, / )
+		
+#define OPERATORS( type ) \
+	LOGIC_OPERATORS( type )\
+	ARITHMETIC_OPERATORS( type )
+
+OPERATORS( float )
+OPERATORS( double )
+OPERATORS( long double )
+
+OPERATORS( char )
+OPERATORS( unsigned char )
+OPERATORS( signed char )
+OPERATORS( unsigned short int )
+OPERATORS( signed short int )
+OPERATORS( unsigned int )
+OPERATORS( signed int )
+OPERATORS( unsigned long int )
+OPERATORS( signed long int )
+OPERATORS( unsigned long long int )
+OPERATORS( signed long long int )
+
+// Prevent Macro-bleed:
+
+#undef OPERATORS
+#undef ARITHMETIC_OPERATORS
+#undef LOGIC_OPERATORS
+#undef ARITHMETIC_OPERATOR
+#undef LOGIC_OPERATOR
+
+FIXED_POINTS_END_NAMESPACE

--- a/Embedded/MaxMix/src/FixedPoints/FixedPoints/SFixedMemberFunctions.h
+++ b/Embedded/MaxMix/src/FixedPoints/FixedPoints/SFixedMemberFunctions.h
@@ -1,0 +1,273 @@
+// Copyright 2017-2018 Pharap
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+FIXED_POINTS_BEGIN_NAMESPACE
+
+//
+// Constructors
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::SFixed(const RawType & value)
+	: value(static_cast<InternalType>(value))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::SFixed()
+	: value(0)
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::SFixed(const IntegerType & integer, const FractionType & fraction)
+	: value((static_cast<InternalType>(integer) << FractionSize) | fraction)
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::SFixed(const char & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<char, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::SFixed(const unsigned char & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<unsigned char, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::SFixed(const signed char & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<signed char, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::SFixed(const unsigned short int & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<unsigned short int, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::SFixed(const signed short int & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<signed short int, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::SFixed(const unsigned int & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<unsigned int, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::SFixed(const signed int & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<signed int, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::SFixed(const unsigned long int & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<unsigned long int, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::SFixed(const signed long int & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<signed long int, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::SFixed(const unsigned long long int & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<unsigned long long int, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::SFixed(const signed long long int & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<signed long long int, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::SFixed(const double & value)
+	: value(static_cast<InternalType>(value * static_cast<double>(Scale)))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::SFixed(const float & value)
+	: value(static_cast<InternalType>(value * static_cast<float>(Scale)))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::SFixed(const long double & value)
+	: value(static_cast<InternalType>(value * static_cast<long double>(Scale)))
+{
+}
+
+//
+// Getters
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr typename SFixed<Integer, Fraction>::InternalType SFixed<Integer, Fraction>::getInternal() const
+{
+	return this->value;
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr typename SFixed<Integer, Fraction>::IntegerType SFixed<Integer, Fraction>::getInteger() const
+{
+	return (static_cast<IntegerType>(this->value >> IntegerShift) & IntegerMask) | ((this->value < 0) ? ~IntegerMask : 0);
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr typename SFixed<Integer, Fraction>::FractionType SFixed<Integer, Fraction>::getFraction() const
+{
+	return static_cast<FractionType>(this->value >> FractionShift) & FractionMask;
+}
+
+//
+// Cast Operators
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::operator IntegerType() const
+{
+	return this->getInteger();
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::operator float() const
+{
+	return (1.0F / Scale) *
+	static_cast<InternalType>
+	((this->value & IdentityMask) |
+	((this->value < 0) ? ~IdentityMask : 0));
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::operator double() const
+{
+	return (1.0 / Scale) *
+	static_cast<InternalType>
+	((this->value & IdentityMask) |
+	((this->value < 0) ? ~IdentityMask : 0));
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction>::operator long double() const
+{
+	return (1.0L / Scale) *
+	static_cast<InternalType>
+	((this->value & IdentityMask) |
+	((this->value < 0) ? ~IdentityMask : 0));
+}
+
+template< unsigned Integer, unsigned Fraction >
+template< unsigned IntegerOut, unsigned FractionOut >
+constexpr SFixed<Integer, Fraction>::operator SFixed<IntegerOut, FractionOut>() const
+{	
+	using OutputType = SFixed<IntegerOut, FractionOut>;
+	using OutputInternalType = typename OutputType::InternalType;
+	using OutputShiftType = typename OutputType::ShiftType;
+	
+	using InputType = SFixed<Integer, Fraction>;
+	using InputShiftType = typename InputType::ShiftType;
+	
+	return
+	(FractionOut > FractionSize) ?
+		OutputType::fromInternal(static_cast<OutputInternalType>(static_cast<OutputShiftType>(this->value) << ((FractionOut > FractionSize) ? (FractionOut - FractionSize) : 0))) :
+	(FractionSize > FractionOut) ?
+		OutputType::fromInternal(static_cast<OutputInternalType>(static_cast<InputShiftType>(this->value) >> ((FractionSize > FractionOut) ? (FractionSize - FractionOut) : 0))) :
+		OutputType::fromInternal(this->value);
+}
+
+//
+// Static Functions
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> SFixed<Integer, Fraction>::fromInternal(const typename SFixed<Integer, Fraction>::InternalType & value)
+{
+	return SFixed<Integer, Fraction>(RawType(value));
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> SFixed<Integer, Fraction>::operator -() const
+{
+	return SFixed<Integer, Fraction>::fromInternal(-this->value);
+}
+
+//
+// Member Operators
+//
+
+template< unsigned Integer, unsigned Fraction >
+SFixed<Integer, Fraction> & SFixed<Integer, Fraction>::operator ++()
+{
+	this->value += (1 << FractionSize);
+	return *this;
+}
+
+template< unsigned Integer, unsigned Fraction >
+SFixed<Integer, Fraction> & SFixed<Integer, Fraction>::operator --()
+{
+	this->value -= (1 << FractionSize);
+	return *this;
+}
+
+//
+// Compound Assignment Operators
+//
+
+template< unsigned Integer, unsigned Fraction >
+SFixed<Integer, Fraction> & SFixed<Integer, Fraction>::operator +=(const SFixed<Integer, Fraction> & other)
+{
+	this->value += other.value;
+	return *this;
+}
+
+template< unsigned Integer, unsigned Fraction >
+SFixed<Integer, Fraction> & SFixed<Integer, Fraction>::operator -=(const SFixed<Integer, Fraction> & other)
+{
+	this->value -= other.value;
+	return *this;
+}
+
+template< unsigned Integer, unsigned Fraction >
+SFixed<Integer, Fraction> & SFixed<Integer, Fraction>::operator *=(const SFixed<Integer, Fraction> & other)
+{
+	using InternalType = typename SFixed<Integer, Fraction>::InternalType;
+	using PrecisionType = typename SFixed<Integer * 2, Fraction * 2>::InternalType;
+	const PrecisionType temp = (static_cast<PrecisionType>(this->value) * static_cast<PrecisionType>(other.value)) >> Fraction;
+	this->value = static_cast<InternalType>(temp);
+	return *this;
+}
+
+template< unsigned Integer, unsigned Fraction >
+SFixed<Integer, Fraction> & SFixed<Integer, Fraction>::operator /=(const SFixed<Integer, Fraction> & other)
+{
+	using InternalType = typename SFixed<Integer, Fraction>::InternalType;
+	using PrecisionType = typename SFixed<Integer * 2, Fraction * 2>::InternalType;
+	const PrecisionType temp = (static_cast<PrecisionType>(this->value) << Fraction) / static_cast<PrecisionType>(other.value);
+	this->value = static_cast<InternalType>(temp);
+	return *this;
+}
+
+FIXED_POINTS_END_NAMESPACE

--- a/Embedded/MaxMix/src/FixedPoints/FixedPoints/UFixed.h
+++ b/Embedded/MaxMix/src/FixedPoints/FixedPoints/UFixed.h
@@ -1,0 +1,220 @@
+// Copyright 2017-2018 Pharap
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "Details.h"
+
+FIXED_POINTS_BEGIN_NAMESPACE
+
+//
+// Declaration
+//
+
+template< unsigned Integer, unsigned Fraction >
+class UFixed
+{
+public:
+	static constexpr uintmax_t IntegerSize = Integer;
+	static constexpr uintmax_t FractionSize = Fraction;
+	static constexpr uintmax_t LogicalSize = IntegerSize + FractionSize;
+	static constexpr uintmax_t Scale = UINTMAX_C(1) << FractionSize;
+
+public:
+	static_assert(LogicalSize <= FIXED_POINTS_DETAILS::BitSize<uintmax_t>::Value, "Platform does not have a native type large enough for UFixed.");
+
+public:
+	using IntegerType = FIXED_POINTS_DETAILS::LeastUInt<IntegerSize>;
+	using FractionType = FIXED_POINTS_DETAILS::LeastUInt<FractionSize>;
+	using InternalType = FIXED_POINTS_DETAILS::LeastUInt<LogicalSize>;
+
+	static constexpr uintmax_t InternalSize = FIXED_POINTS_DETAILS::BitSize<InternalType>::Value;
+	
+	using ShiftType = FIXED_POINTS_DETAILS::LeastUInt<LogicalSize>;
+	using MaskType = FIXED_POINTS_DETAILS::LeastUInt<LogicalSize>;
+		
+public:
+	static constexpr ShiftType IntegerShift = FractionSize;
+	static constexpr ShiftType FractionShift = 0;
+	
+	static constexpr MaskType IntegerMask = FIXED_POINTS_DETAILS::IdentityMask<IntegerSize>::Value;
+	static constexpr MaskType FractionMask = FIXED_POINTS_DETAILS::IdentityMask<FractionSize>::Value;
+	
+	static constexpr MaskType IdentityMask = (IntegerMask << IntegerShift) | (FractionMask << FractionShift);
+	
+	static constexpr MaskType MidpointMask = FIXED_POINTS_DETAILS::MsbMask<FractionSize>::Value;
+	static constexpr MaskType LesserMidpointMask = MidpointMask - 1;
+
+protected:
+	class RawType
+	{
+	private:
+		const InternalType value;
+
+	public:
+		constexpr inline explicit RawType(const InternalType & value) : value(value) {}
+		constexpr inline explicit operator InternalType() const { return this->value; }
+	};
+
+protected:
+	InternalType value;
+
+protected:
+	constexpr UFixed(const RawType & value);
+	
+public:
+	constexpr UFixed();
+	constexpr UFixed(const IntegerType & integer, const FractionType & fraction);
+	constexpr UFixed(const char & value);
+	constexpr UFixed(const unsigned char & value);
+	constexpr UFixed(const signed char & value);
+	constexpr UFixed(const unsigned short int & value);
+	constexpr UFixed(const signed short int & value);
+	constexpr UFixed(const unsigned int & value);
+	constexpr UFixed(const signed int & value);
+	constexpr UFixed(const unsigned long int & value);
+	constexpr UFixed(const signed long int & value);
+	constexpr UFixed(const unsigned long long int & value);
+	constexpr UFixed(const signed long long int & value);
+	constexpr UFixed(const double & value);
+	constexpr UFixed(const float & value);
+	constexpr UFixed(const long double & value);
+	
+public:
+	constexpr InternalType getInternal() const;
+	constexpr IntegerType getInteger() const;
+	constexpr FractionType getFraction() const;
+
+	constexpr explicit operator IntegerType() const;
+	constexpr explicit operator float() const;
+	constexpr explicit operator double() const;
+	constexpr explicit operator long double() const;
+
+	template< unsigned IntegerOut, unsigned FractionOut >
+	constexpr explicit operator UFixed<IntegerOut, FractionOut>() const;
+
+	static constexpr UFixed fromInternal(const InternalType & value);
+
+	UFixed & operator ++();
+	UFixed & operator --();
+	UFixed & operator +=(const UFixed & other);
+	UFixed & operator -=(const UFixed & other);
+	UFixed & operator *=(const UFixed & other);
+	UFixed & operator /=(const UFixed & other);
+	
+public:
+	static constexpr UFixed Epsilon = UFixed::fromInternal(1);
+	static constexpr UFixed MinValue = UFixed::fromInternal(0);
+	static constexpr UFixed MaxValue = UFixed::fromInternal(~0);
+	
+	// 40 digits is probably enough for these
+	static constexpr UFixed Pi = 3.1415926535897932384626433832795028841971;
+	static constexpr UFixed E = 2.718281828459045235360287471352662497757;
+	static constexpr UFixed Phi = 1.6180339887498948482045868343656381177203;
+	static constexpr UFixed Tau = 6.2831853071795864769252867665590057683943;
+};
+
+
+//
+// Free functions
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer * 2, Fraction * 2> multiply(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right);
+
+
+//
+// Basic Logic Operations
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator ==(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator !=(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator <(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator >(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator <=(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator >=(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right);
+
+//
+// Inter-size Logic Operations
+//
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator ==(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right);
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator !=(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right);
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator <(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right);
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator >(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right);
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator <=(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right);
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator >=(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right);
+
+//
+// Basic Arithmetic Operations
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> operator +(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> operator -(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> operator *(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> operator /(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right);
+
+//
+// Inter-size Arithmetic Operations
+//
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr auto operator +(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right)
+	-> FIXED_POINTS_DETAILS::LargerType< UFixed<IntegerLeft, FractionLeft>, UFixed<IntegerRight, FractionRight> >;
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr auto operator -(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right)
+	-> FIXED_POINTS_DETAILS::LargerType< UFixed<IntegerLeft, FractionLeft>, UFixed<IntegerRight, FractionRight> >;
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr auto operator *(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right)
+	-> FIXED_POINTS_DETAILS::LargerType< UFixed<IntegerLeft, FractionLeft>, UFixed<IntegerRight, FractionRight> >;
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+inline constexpr auto operator /(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right)
+	-> FIXED_POINTS_DETAILS::LargerType< UFixed<IntegerLeft, FractionLeft>, UFixed<IntegerRight, FractionRight> >;
+	
+FIXED_POINTS_END_NAMESPACE
+
+#include "UFixedMemberFunctions.h"
+#include "UFixedFreeFunctions.h"

--- a/Embedded/MaxMix/src/FixedPoints/FixedPoints/UFixedFreeFunctions.h
+++ b/Embedded/MaxMix/src/FixedPoints/FixedPoints/UFixedFreeFunctions.h
@@ -1,0 +1,323 @@
+// Copyright 2017-2018 Pharap
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+FIXED_POINTS_BEGIN_NAMESPACE
+
+//
+// multiply
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer * 2, Fraction * 2> multiply(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right)
+{
+	static_assert((Integer * 2 + Fraction * 2) <= FIXED_POINTS_DETAILS::BitSize<uintmax_t>::Value, "Multiplication cannot be performed, the result type would be too large");
+	
+	using ResultType = UFixed<Integer * 2, Fraction * 2>;
+	using InternalType = typename ResultType::InternalType;
+	return ResultType::fromInternal(static_cast<InternalType>(static_cast<InternalType>(left.getInternal()) * static_cast<InternalType>(right.getInternal())));
+}
+
+//
+// Basic Logic Operations
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator ==(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right)
+{
+	return (left.getInternal() == right.getInternal());
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator !=(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right)
+{
+	return (left.getInternal() != right.getInternal());
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator <(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right)
+{
+	return (left.getInternal() < right.getInternal());
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator >(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right)
+{
+	return (left.getInternal() > right.getInternal());
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator <=(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right)
+{
+	return (left.getInternal() <= right.getInternal());
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool operator >=(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right)
+{
+	return (left.getInternal() >= right.getInternal());
+}
+
+//
+// Inter-size Logic Operations
+//
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator ==(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right)
+{
+	using LeftType = UFixed<IntegerLeft, FractionLeft>;
+	using RightType = UFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator == has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) == static_cast<CompareType>(right));
+}
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator !=(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right)
+{
+	using LeftType = UFixed<IntegerLeft, FractionLeft>;
+	using RightType = UFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator != has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) != static_cast<CompareType>(right));
+}
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator <(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right)
+{
+	using LeftType = UFixed<IntegerLeft, FractionLeft>;
+	using RightType = UFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator < has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) < static_cast<CompareType>(right));
+}
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator >(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right)
+{
+	using LeftType = UFixed<IntegerLeft, FractionLeft>;
+	using RightType = UFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator > has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) > static_cast<CompareType>(right));
+}
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator <=(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right)
+{
+	using LeftType = UFixed<IntegerLeft, FractionLeft>;
+	using RightType = UFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator <= has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) <= static_cast<CompareType>(right));
+}
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr bool operator >=(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right)
+{
+	using LeftType = UFixed<IntegerLeft, FractionLeft>;
+	using RightType = UFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator >= has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) >= static_cast<CompareType>(right));
+}
+
+//
+// Basic Arithmetic Operations
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> operator +(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right)
+{
+	using InternalType = typename UFixed<Integer, Fraction>::InternalType;
+	return UFixed<Integer, Fraction>::fromInternal(static_cast<InternalType>(left.getInternal() + right.getInternal()));
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> operator -(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right)
+{
+	using InternalType = typename UFixed<Integer, Fraction>::InternalType;
+	return UFixed<Integer, Fraction>::fromInternal(static_cast<InternalType>(left.getInternal() - right.getInternal()));
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> operator *(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right)
+{
+	static_assert((Integer * 2 + Fraction * 2) <= FIXED_POINTS_DETAILS::BitSize<uintmax_t>::Value, "Multiplication cannot be performed, the intermediary type would be too large");
+	
+	using InternalType = typename UFixed<Integer, Fraction>::InternalType;
+	using PrecisionType = typename UFixed<Integer * 2, Fraction * 2>::InternalType;
+	return UFixed<Integer, Fraction>::fromInternal(static_cast<InternalType>((static_cast<PrecisionType>(left.getInternal()) * static_cast<PrecisionType>(right.getInternal())) >> Fraction));
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> operator /(const UFixed<Integer, Fraction> & left, const UFixed<Integer, Fraction> & right)
+{
+	using InternalType = typename UFixed<Integer, Fraction>::InternalType;
+	using PrecisionType = typename UFixed<Integer * 2, Fraction * 2>::InternalType;
+	return UFixed<Integer, Fraction>::fromInternal(static_cast<InternalType>((static_cast<PrecisionType>(left.getInternal()) << Fraction) / static_cast<PrecisionType>(right.getInternal())));
+}
+
+//
+// Inter-size Arithmetic Operations
+//
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr auto operator +(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right)
+	-> FIXED_POINTS_DETAILS::LargerType< UFixed<IntegerLeft, FractionLeft>, UFixed<IntegerRight, FractionRight> >
+{
+	using LeftType = UFixed<IntegerLeft, FractionLeft>;
+	using RightType = UFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator + has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) + static_cast<CompareType>(right));
+}
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr auto operator -(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right)
+	-> FIXED_POINTS_DETAILS::LargerType< UFixed<IntegerLeft, FractionLeft>, UFixed<IntegerRight, FractionRight> >
+{
+	using LeftType = UFixed<IntegerLeft, FractionLeft>;
+	using RightType = UFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator - has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) - static_cast<CompareType>(right));
+}
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr auto operator *(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right)
+	-> FIXED_POINTS_DETAILS::LargerType< UFixed<IntegerLeft, FractionLeft>, UFixed<IntegerRight, FractionRight> >
+{
+	using LeftType = UFixed<IntegerLeft, FractionLeft>;
+	using RightType = UFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator * has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) * static_cast<CompareType>(right));
+}
+
+
+template< unsigned IntegerLeft, unsigned FractionLeft, unsigned IntegerRight, unsigned FractionRight >
+constexpr auto operator /(const UFixed<IntegerLeft, FractionLeft> & left, const UFixed<IntegerRight, FractionRight> & right)
+	-> FIXED_POINTS_DETAILS::LargerType< UFixed<IntegerLeft, FractionLeft>, UFixed<IntegerRight, FractionRight> >
+{
+	using LeftType = UFixed<IntegerLeft, FractionLeft>;
+	using RightType = UFixed<IntegerRight, FractionRight>;
+
+	static_assert(LeftType::InternalSize != RightType::InternalSize, "operator / has ambiguous result");
+	
+	using CompareType = FIXED_POINTS_DETAILS::LargerType<LeftType, RightType>;
+	
+	return (static_cast<CompareType>(left) / static_cast<CompareType>(right));
+}
+
+//
+// Literal-type Operators
+// Generated by macro to make maintenance easier
+//
+
+#define LOGIC_OPERATOR( type, op )\
+	template< unsigned Integer, unsigned Fraction >\
+	constexpr bool operator op (const UFixed<Integer, Fraction> & left, const type & right)\
+	{\
+		return (left op UFixed<Integer, Fraction>(right));\
+	}\
+	\
+	template< unsigned Integer, unsigned Fraction >\
+	constexpr bool operator op (const type & left, const UFixed<Integer, Fraction> & right)\
+	{\
+		return (UFixed<Integer, Fraction>(left) op right);\
+	}
+
+#define ARITHMETIC_OPERATOR( type, op )\
+	template< unsigned Integer, unsigned Fraction >\
+	constexpr UFixed<Integer, Fraction> operator op (const UFixed<Integer, Fraction> & left, const type & right)\
+	{\
+		return (left op UFixed<Integer, Fraction>(right));\
+	}\
+	\
+	template< unsigned Integer, unsigned Fraction >\
+	constexpr UFixed<Integer, Fraction> operator op (const type & left, const UFixed<Integer, Fraction> & right)\
+	{\
+		return (UFixed<Integer, Fraction>(left) op right);\
+	}
+	
+#define LOGIC_OPERATORS( type )\
+	LOGIC_OPERATOR( type, == )\
+	LOGIC_OPERATOR( type, != )\
+	LOGIC_OPERATOR( type, < )\
+	LOGIC_OPERATOR( type, <= )\
+	LOGIC_OPERATOR( type, > )\
+	LOGIC_OPERATOR( type, >= )
+			
+#define ARITHMETIC_OPERATORS( type ) \
+	ARITHMETIC_OPERATOR( type, + )\
+	ARITHMETIC_OPERATOR( type, - )\
+	ARITHMETIC_OPERATOR( type, * )\
+	ARITHMETIC_OPERATOR( type, / )
+		
+#define OPERATORS( type ) \
+	LOGIC_OPERATORS( type )\
+	ARITHMETIC_OPERATORS( type )
+
+OPERATORS( float )
+OPERATORS( double )
+OPERATORS( long double )
+
+OPERATORS( char )
+OPERATORS( unsigned char )
+OPERATORS( signed char )
+OPERATORS( unsigned short int )
+OPERATORS( signed short int )
+OPERATORS( unsigned int )
+OPERATORS( signed int )
+OPERATORS( unsigned long int )
+OPERATORS( signed long int )
+OPERATORS( unsigned long long int )
+OPERATORS( signed long long int )
+
+// Prevent Macro-bleed:
+
+#undef OPERATORS
+#undef ARITHMETIC_OPERATORS
+#undef LOGIC_OPERATORS
+#undef ARITHMETIC_OPERATOR
+#undef LOGIC_OPERATOR
+
+FIXED_POINTS_END_NAMESPACE

--- a/Embedded/MaxMix/src/FixedPoints/FixedPoints/UFixedMemberFunctions.h
+++ b/Embedded/MaxMix/src/FixedPoints/FixedPoints/UFixedMemberFunctions.h
@@ -1,0 +1,258 @@
+// Copyright 2017-2018 Pharap
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+FIXED_POINTS_BEGIN_NAMESPACE
+
+//
+// Constructors
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::UFixed(const RawType & value)
+	: value(static_cast<InternalType>(value))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::UFixed()
+	: value(0)
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::UFixed(const IntegerType & integer, const FractionType & fraction)
+	: value((static_cast<InternalType>(integer) << FractionSize) | fraction)
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::UFixed(const char & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<char, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::UFixed(const unsigned char & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<unsigned char, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::UFixed(const signed char & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<signed char, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::UFixed(const unsigned short int & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<unsigned short int, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::UFixed(const signed short int & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<signed short int, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::UFixed(const unsigned int & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<unsigned int, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::UFixed(const signed int & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<signed int, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::UFixed(const unsigned long int & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<unsigned long int, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::UFixed(const signed long int & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<signed long int, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::UFixed(const unsigned long long int & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<unsigned long long int, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::UFixed(const signed long long int & value)
+	: value(static_cast<InternalType>(static_cast< FIXED_POINTS_DETAILS::LargerType<signed long long int, InternalType> >(value) << FractionSize))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::UFixed(const double & value)
+	: value(static_cast<InternalType>(value * static_cast<double>(Scale)))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::UFixed(const float & value)
+	: value(static_cast<InternalType>(value * static_cast<float>(Scale)))
+{
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::UFixed(const long double & value)
+	: value(static_cast<InternalType>(value * static_cast<long double>(Scale)))
+{
+}
+
+//
+// Getters
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr typename UFixed<Integer, Fraction>::InternalType UFixed<Integer, Fraction>::getInternal() const
+{
+	return this->value;
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr typename UFixed<Integer, Fraction>::IntegerType UFixed<Integer, Fraction>::getInteger() const
+{
+	return static_cast<IntegerType>(this->value >> IntegerShift) & IntegerMask;
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr typename UFixed<Integer, Fraction>::FractionType UFixed<Integer, Fraction>::getFraction() const
+{
+	return static_cast<FractionType>(this->value >> FractionShift) & FractionMask;
+}
+
+//
+// Cast Operators
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::operator IntegerType() const
+{
+	return this->getInteger();
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::operator float() const
+{
+	return ((this->value & IdentityMask) * (1.0F / Scale));
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::operator double() const
+{
+	return ((this->value & IdentityMask) * (1.0 / Scale));
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction>::operator long double() const
+{
+	return ((this->value & IdentityMask) * (1.0L / Scale));
+}
+
+template< unsigned Integer, unsigned Fraction >
+template< unsigned IntegerOut, unsigned FractionOut >
+constexpr UFixed<Integer, Fraction>::operator UFixed<IntegerOut, FractionOut>() const
+{
+	using OutputType = UFixed<IntegerOut, FractionOut>;
+	using OutputInternalType = typename OutputType::InternalType;
+	using OutputShiftType = typename OutputType::ShiftType;
+	
+	using InputType = UFixed<Integer, Fraction>;
+	using InputShiftType = typename InputType::ShiftType;
+	
+	return
+	(FractionOut > FractionSize) ?
+		OutputType::fromInternal(static_cast<OutputInternalType>(static_cast<OutputShiftType>(this->value) << ((FractionOut > FractionSize) ? (FractionOut - FractionSize) : 0))) :
+	(FractionSize > FractionOut) ?
+		OutputType::fromInternal(static_cast<OutputInternalType>(static_cast<InputShiftType>(this->value) >> ((FractionSize > FractionOut) ? (FractionSize - FractionOut) : 0))) :
+		OutputType::fromInternal(this->value);
+}
+
+//
+// Static Functions
+//
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> UFixed<Integer, Fraction>::fromInternal(const typename UFixed<Integer, Fraction>::InternalType & value)
+{
+	return UFixed<Integer, Fraction>(RawType(value));
+}
+
+//
+// Member Operators
+//
+
+template< unsigned Integer, unsigned Fraction >
+UFixed<Integer, Fraction> & UFixed<Integer, Fraction>::operator ++()
+{
+	this->value += (1 << FractionSize);
+	return *this;
+}
+
+template< unsigned Integer, unsigned Fraction >
+UFixed<Integer, Fraction> & UFixed<Integer, Fraction>::operator --()
+{
+	this->value -= (1 << FractionSize);
+	return *this;
+}
+
+//
+// Compound Assignment Operators
+//
+
+template< unsigned Integer, unsigned Fraction >
+UFixed<Integer, Fraction> & UFixed<Integer, Fraction>::operator +=(const UFixed<Integer, Fraction> & other)
+{
+	this->value += other.value;
+	return *this;
+}
+
+template< unsigned Integer, unsigned Fraction >
+UFixed<Integer, Fraction> & UFixed<Integer, Fraction>::operator -=(const UFixed<Integer, Fraction> & other)
+{
+	this->value -= other.value;
+	return *this;
+}
+
+template< unsigned Integer, unsigned Fraction >
+UFixed<Integer, Fraction> & UFixed<Integer, Fraction>::operator *=(const UFixed<Integer, Fraction> & other)
+{
+	using InternalType = typename UFixed<Integer, Fraction>::InternalType;
+	using PrecisionType = typename UFixed<Integer * 2, Fraction * 2>::InternalType;
+	const PrecisionType temp = (static_cast<PrecisionType>(this->value) * static_cast<PrecisionType>(other.value)) >> FractionSize;
+	this->value = static_cast<InternalType>(temp);
+	return *this;
+}
+
+template< unsigned Integer, unsigned Fraction >
+UFixed<Integer, Fraction> & UFixed<Integer, Fraction>::operator /=(const UFixed<Integer, Fraction> & other)
+{
+	using InternalType = typename UFixed<Integer, Fraction>::InternalType;
+	using PrecisionType = typename UFixed<Integer * 2, Fraction * 2>::InternalType;
+	const PrecisionType temp = (static_cast<PrecisionType>(this->value) << FractionSize) / static_cast<PrecisionType>(other.value);
+	this->value = static_cast<InternalType>(temp);
+	return *this;
+}
+
+FIXED_POINTS_END_NAMESPACE

--- a/Embedded/MaxMix/src/FixedPoints/FixedPoints/Utils.h
+++ b/Embedded/MaxMix/src/FixedPoints/FixedPoints/Utils.h
@@ -1,0 +1,256 @@
+// Copyright 2017-2018 Pharap
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "Details.h"
+#include "UFixed.h"
+#include "SFixed.h"
+
+//
+// Declaration
+//
+
+FIXED_POINTS_BEGIN_NAMESPACE
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> floorFixed(const UFixed<Integer, Fraction> & value);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> floorFixed(const SFixed<Integer, Fraction> & value);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> ceilFixed(const UFixed<Integer, Fraction> & value);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> ceilFixed(const SFixed<Integer, Fraction> & value);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> roundFixed(const UFixed<Integer, Fraction> & value);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> roundFixed(const SFixed<Integer, Fraction> & value);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool signbitFixed(const SFixed<Integer, Fraction> & value);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> absFixed(const SFixed<Integer, Fraction> & value);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> copysignFixed(const SFixed<Integer, Fraction> & x, const SFixed<Integer, Fraction> & y);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> nextafterFixed(const SFixed<Integer, Fraction> & from, const SFixed<Integer, Fraction> & to);
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> nextafterFixed(const UFixed<Integer, Fraction> & from, const UFixed<Integer, Fraction> & to);
+
+//
+// Unsigned Random
+//
+
+#if !defined(FIXED_POINTS_NO_RANDOM)
+template< unsigned Integer, unsigned Fraction >
+UFixed<Integer, Fraction> randomUFixed();
+
+template< unsigned Integer, unsigned Fraction >
+UFixed<Integer, Fraction> randomUFixed(const UFixed<Integer, Fraction> & exclusiveUpperBound);
+
+template< unsigned Integer, unsigned Fraction >
+UFixed<Integer, Fraction> randomUFixed(const UFixed<Integer, Fraction> & inclusiveLowerBound, const UFixed<Integer, Fraction> & exclusiveUpperBound);
+#endif
+
+//
+// Signed Random
+//
+
+#if !defined(FIXED_POINTS_NO_RANDOM)
+template< unsigned Integer, unsigned Fraction >
+SFixed<Integer, Fraction> randomSFixed();
+
+template< unsigned Integer, unsigned Fraction >
+SFixed<Integer, Fraction> randomSFixed(const SFixed<Integer, Fraction> & exclusiveUpperBound);
+
+template< unsigned Integer, unsigned Fraction >
+SFixed<Integer, Fraction> randomSFixed(const SFixed<Integer, Fraction> & inclusiveLowerBound, const SFixed<Integer, Fraction> & exclusiveUpperBound);
+#endif
+
+FIXED_POINTS_END_NAMESPACE
+
+//
+// Definition
+//
+
+FIXED_POINTS_BEGIN_NAMESPACE
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> floorFixed(const UFixed<Integer, Fraction> & value)
+{
+	using OutputType = UFixed<Integer, Fraction>;
+	using InternalType = typename OutputType::InternalType;
+	return OutputType::fromInternal(static_cast<InternalType>(value.getInternal() & ~OutputType::FractionMask));
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> floorFixed(const SFixed<Integer, Fraction> & value)
+{
+	using OutputType = SFixed<Integer, Fraction>;
+	using InternalType = typename OutputType::InternalType;
+	return OutputType::fromInternal(static_cast<InternalType>(value.getInternal() & ~OutputType::FractionMask));
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> ceilFixed(const UFixed<Integer, Fraction> & value)
+{	
+	return UFixed<Integer, Fraction>((value.getFraction() == 0) ? value.getInteger() : (value.getInteger() + 1), 0);
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> ceilFixed(const SFixed<Integer, Fraction> & value)
+{
+	return SFixed<Integer, Fraction>((value.getFraction() == 0) ? value.getInteger() : (value.getInteger() + 1), 0);
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> roundFixed(const UFixed<Integer, Fraction> & value)
+{
+	using OutputType = UFixed<Integer, Fraction>;
+	return (value.getFraction() >= OutputType(0.5).getFraction()) ? ceilFixed(value) : floorFixed(value);
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> roundFixed(const SFixed<Integer, Fraction> & value)
+{
+	using OutputType = SFixed<Integer, Fraction>;
+	return		
+		signbitFixed(value) ?
+		((value.getFraction() <= OutputType(0.5).getFraction()) ? floorFixed(value) : ceilFixed(value)) :
+		((value.getFraction() >= OutputType(0.5).getFraction()) ? ceilFixed(value) : floorFixed(value));
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> truncFixed(const UFixed<Integer, Fraction> & value)
+{
+	return UFixed<Integer, Fraction>(value.getInteger(), 0);
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> truncFixed(const SFixed<Integer, Fraction> & value)
+{
+	using OutputType = SFixed<Integer, Fraction>;
+	return 
+		(value.getInternal() < 0) ?
+		OutputType::fromInternal(value.getInternal() & ~OutputType::FractionMask) + OutputType(1, 0) :
+		OutputType::fromInternal(value.getInternal() & ~OutputType::FractionMask);
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr bool signbitFixed(const SFixed<Integer, Fraction> & value)
+{
+	return (value.getInternal() < 0);
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> absFixed(const SFixed<Integer, Fraction> & value)
+{
+	return (signbitFixed(value)) ? -value : value;
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> copysignFixed(const SFixed<Integer, Fraction> & x, const SFixed<Integer, Fraction> & y)
+{
+	return (signbitFixed(x) != signbitFixed(y)) ? -x : x;
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr SFixed<Integer, Fraction> nextafterFixed(const SFixed<Integer, Fraction> & from, const SFixed<Integer, Fraction> & to)
+{
+	using ResultType = SFixed<Integer, Fraction>;
+	return
+		(from < to) ?
+		ResultType::fromInternal(from.getInternal() + 1) :
+		(from > to) ?
+		ResultType::fromInternal(from.getInternal() - 1) :
+		to;
+}
+
+template< unsigned Integer, unsigned Fraction >
+constexpr UFixed<Integer, Fraction> nextafterFixed(const UFixed<Integer, Fraction> & from, const UFixed<Integer, Fraction> & to)
+{
+	using ResultType = UFixed<Integer, Fraction>;
+	return
+		(from < to) ?
+		ResultType::fromInternal(from.getInternal() + 1) :
+		(from > to) ?
+		ResultType::fromInternal(from.getInternal() - 1) :
+		to;
+}
+
+//
+// Unsigned Random
+//
+
+#if !defined(FIXED_POINTS_NO_RANDOM)
+template< unsigned Integer, unsigned Fraction >
+UFixed<Integer, Fraction> randomUFixed()
+{
+	using InternalType = typename UFixed<Integer, Fraction>::InternalType;
+	return UFixed<Integer, Fraction>::fromInternal(FIXED_POINTS_DETAILS::RandomHelper<InternalType>::Random());
+}
+
+template< unsigned Integer, unsigned Fraction >
+UFixed<Integer, Fraction> randomUFixed(const UFixed<Integer, Fraction> & exclusiveUpperBound)
+{
+	using InternalType = typename UFixed<Integer, Fraction>::InternalType;
+	return UFixed<Integer, Fraction>::fromInternal(FIXED_POINTS_DETAILS::RandomHelper<InternalType>::Random() % exclusiveUpperBound.getInternal());
+}
+
+template< unsigned Integer, unsigned Fraction >
+UFixed<Integer, Fraction> randomUFixed(const UFixed<Integer, Fraction> & inclusiveLowerBound, const UFixed<Integer, Fraction> & exclusiveUpperBound)
+{
+	using InternalType = typename UFixed<Integer, Fraction>::InternalType;
+	return UFixed<Integer, Fraction>::fromInternal(inclusiveLowerBound.getInternal() + (FIXED_POINTS_DETAILS::RandomHelper<InternalType>::Random() % (exclusiveUpperBound.getInternal() - inclusiveLowerBound.getInternal())));
+}
+#endif
+
+//
+// Signed Random
+//
+
+#if !defined(FIXED_POINTS_NO_RANDOM)
+template< unsigned Integer, unsigned Fraction >
+SFixed<Integer, Fraction> randomSFixed()
+{
+	using InternalType = typename SFixed<Integer, Fraction>::InternalType;
+	return SFixed<Integer, Fraction>::fromInternal(FIXED_POINTS_DETAILS::RandomHelper<InternalType>::Random());
+}
+
+template< unsigned Integer, unsigned Fraction >
+SFixed<Integer, Fraction> randomSFixed(const SFixed<Integer, Fraction> & exclusiveUpperBound)
+{
+	using InternalType = typename SFixed<Integer, Fraction>::InternalType;
+	return SFixed<Integer, Fraction>::fromInternal(FIXED_POINTS_DETAILS::RandomHelper<InternalType>::Random() % exclusiveUpperBound.getInternal());
+}
+
+template< unsigned Integer, unsigned Fraction >
+SFixed<Integer, Fraction> randomSFixed(const SFixed<Integer, Fraction> & inclusiveLowerBound, const SFixed<Integer, Fraction> & exclusiveUpperBound)
+{
+	using InternalType = typename SFixed<Integer, Fraction>::InternalType;
+	auto value = FIXED_POINTS_DETAILS::RandomHelper<InternalType>::Random();
+	return SFixed<Integer, Fraction>::fromInternal(inclusiveLowerBound.getInternal() + (abs(value) % (exclusiveUpperBound.getInternal() - inclusiveLowerBound.getInternal())));
+}
+#endif
+
+FIXED_POINTS_END_NAMESPACE

--- a/Embedded/MaxMix/src/FixedPoints/FixedPointsCommon.h
+++ b/Embedded/MaxMix/src/FixedPoints/FixedPointsCommon.h
@@ -1,0 +1,15 @@
+// Copyright 2017-2018 Pharap
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "FixedPointsCommon/FixedPointsCommon.h"

--- a/Embedded/MaxMix/src/FixedPoints/FixedPointsCommon/FixedPointsCommon.h
+++ b/Embedded/MaxMix/src/FixedPoints/FixedPointsCommon/FixedPointsCommon.h
@@ -1,0 +1,18 @@
+// Copyright 2017-2018 Pharap
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../FixedPoints.h"
+
+#include "SFixedCommon.h"
+#include "UFixedCommon.h"

--- a/Embedded/MaxMix/src/FixedPoints/FixedPointsCommon/SFixedCommon.h
+++ b/Embedded/MaxMix/src/FixedPoints/FixedPointsCommon/SFixedCommon.h
@@ -1,0 +1,29 @@
+// Copyright 2017-2018 Pharap
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "../FixedPoints.h" 
+
+FIXED_POINTS_BEGIN_NAMESPACE
+using SQ3x4 = SFixed<3, 4>;
+using SQ7x8 = SFixed<7, 8>;
+using SQ15x16 = SFixed<15, 16>;
+using SQ31x32 = SFixed<31, 32>;
+
+using SQ1x6 = SFixed<1, 6>;
+using SQ1x14 = SFixed<1, 14>;
+using SQ1x30 = SFixed<1, 30>;
+using SQ1x62 = SFixed<1, 62>;
+FIXED_POINTS_END_NAMESPACE

--- a/Embedded/MaxMix/src/FixedPoints/FixedPointsCommon/UFixedCommon.h
+++ b/Embedded/MaxMix/src/FixedPoints/FixedPointsCommon/UFixedCommon.h
@@ -1,0 +1,29 @@
+// Copyright 2017-2018 Pharap
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once 
+ 
+#include "../FixedPoints.h" 
+ 
+FIXED_POINTS_BEGIN_NAMESPACE
+using UQ4x4 = UFixed<4, 4>;
+using UQ8x8 = UFixed<8, 8>;
+using UQ16x16 = UFixed<16, 16>;
+using UQ32x32 = UFixed<32, 32>;
+
+using UQ1x7 = UFixed<1, 7>;
+using UQ1x15 = UFixed<1, 15>;
+using UQ1x31 = UFixed<1, 31>;
+using UQ1x63 = UFixed<1, 63>;
+FIXED_POINTS_END_NAMESPACE

--- a/Embedded/MaxMix/src/FixedPoints/Meta/LICENSE
+++ b/Embedded/MaxMix/src/FixedPoints/Meta/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Embedded/MaxMix/src/FixedPoints/Meta/README.md
+++ b/Embedded/MaxMix/src/FixedPoints/Meta/README.md
@@ -1,0 +1,186 @@
+# FixedPoints
+A portable fixed point arithmetic library.
+
+Some knowledge of how fixed point types are formatted is required to used this library to full effect.
+No knowledge of how these operations are implemented is required to use them.
+
+This library was written with Arduino in mind, as well as CPUs with limited floating point support.
+However, given the templated nature of the library, it should still function on a wide variety of CPUs.
+
+## Project Showcase
+
+Here's a list of projects that use `FixedPoints`:
+
+* [1943](https://github.com/filmote/Nineteen43) for the [Arduboy](https://arduboy.com/) by [@filmote](https://github.com/filmote)
+* [XOD Powered Rechargeable Solar Lamp](http://www.instructables.com/id/XOD-powered-Rechargeable-Solar-Lamp/) by [Victorian DeLorean](http://www.instructables.com/member/Victorian%20DeLorean/)
+* [Pod Manager](https://github.com/felipemanga/PodManager) for the [Arduboy](https://arduboy.com/) by [@felipemanga](https://github.com/felipemanga)
+
+If you have a project that uses `FixedPoints` and would like your work to be showcased here,
+please [raise an issue](https://github.com/Pharap/FixedPointsArduino/issues/new).
+
+## Requirements:
+
+- The Compiler must be C++11 compliant.
+- The user should ideally be familar with the [Q number format](https://en.wikipedia.org/wiki/Q_(number_format)) for fixed points.
+
+## Licence
+
+This code uses the Apache 2.0 Licence.
+This means:
+
+- This code comes with _no warranty_.
+  - The licensor and any contributors **cannot** be held liable for damages.
+- If you use this code, modified or unmodified:
+  - You **must** package a copy of LICENCE with your code.
+  - You **must** package a copy of NOTICE with your code.
+  - You are not required to distribute the source code.
+- You **must not** use any trademarks owned by the licensor.
+  - Unless you have specific permission to do so.
+- You **may** modify the source code.
+  - If you modify the code, you **must** state this fact prominently within the source file.
+    - E.g. in a comment at the top of the source file.
+  - You are under no obligation to distribute the source code of your modifications.
+- You may incorporate any part of the code into another project.
+  - That project **may** use a different licence.
+  - That code **must** retain the Apache 2.0 licence notice, including the copyright notice.
+  - If the code is modified, the modifications **may** be published under a different licence.
+    - The Apache 2.0 licence still applies to unmodified portions.
+    - The copyright and licence notices for the unmodified portions **must** still be prominently displayed.
+    - It is advised that you do not do this, as it is highly unusual and untested in court.
+
+## Conditional Compilation
+
+These are symbols you can define prior to library inclusion to alter the behaviour of the library.
+
+- `FIXED_POINTS_USE_NAMESPACE`: Define this to wrap all classes and functions in the namespace `FixedPoints`. Useful for preventing naming conflicts.
+- `FIXED_POINTS_NO_RANDOM`: Define this to disable the random utility functions. Useful for systems that don't have access to `long random(void)` from avr-libc.
+
+## FAQ
+
+* Why can't I multiply `UQ32x32` or `SQ31x32` by another type?
+  * Because it would require a 128-bit integer type to provide enough precision for accurate multiplication.
+
+## Contents
+This library supplies two core types and sixteen type aliases.
+
+### Defines
+
+- `FIXED_POINTS_NAMESPACE`: The namespace used by FixedPoints. This is empty unless `FIXED_POINTS_USE_NAMESPACE` is defined prior to inclusion.
+- `FIXED_POINTS_DETAILS`: An infrastructure macro that should not be used in user code. It is safe to undefine this if it is causing problems.
+- `FIXED_POINTS_BEGIN_NAMESPACE`: An infrastructure macro that should not be used in user code. It is safe to undefine this if it is causing problems.
+- `FIXED_POINTS_END_NAMESPACE`: An infrastructure macro that should not be used in user code. It is safe to undefine this if it is causing problems.
+
+### Core Types:
+The core types are provided by `FixedPoints.h`.
+
+- `UFixed<I, F>`: An unsigned fixed point type where I is the number of bits used for the integer part of the number and F is the number of bits used for the fractional part of the number.  
+- `SFixed<I, F>`: An signed fixed point type where I is the number of bits used for the integer part of the number (excluding the implicit sign bit) and F is the number of bits used for the fractional part of the number.
+
+### Aliases:
+The common aliases are provided by `FixedPointsCommon.h`.
+
+- `UQ4x4`: An alias for `UFixed<4, 4>`, an 8-bit unsigned fixed point in the Q4.4 format.
+- `UQ8x8`: An alias for `UFixed<8, 8>`, a 16-bit unsigned fixed point in the Q8.8 format.
+- `UQ16x16`: An alias for `UFixed<16, 16>`, a 32-bit unsigned fixed point in the Q16.16 format.
+- `UQ32x32`: An alias for `UFixed<32, 32>`, a 64-bit unsigned fixed point in the Q32.32 format.
+- `UQ1x7`: An alias for `UFixed<1, 7>`, an 8-bit unsigned fixed point in the Q1.7 format.
+- `UQ1x15`: An alias for `UFixed<1, 15>`, a 16-bit unsigned fixed point in the Q1.15 format.
+- `UQ1x31`: An alias for `UFixed<1, 31>`, a 32-bit unsigned fixed point in the Q1.31 format.
+- `UQ1x63`: An alias for `UFixed<1, 63>`, a 64-bit unsigned fixed point in the Q1.63 format.
+- `SQ3x4`: An alias for `SFixed<3, 4>`, an 8-bit signed fixed point in the Q3.4 format with implicit sign bit.
+- `SQ7x8`: An alias for `SFixed<7, 8>`, a 16-bit signed fixed point in the Q7.8 format with implicit sign bit.
+- `SQ15x16`: An alias for `SFixed<15, 16>`, a 32-bit signed fixed point in the Q15.16 format with implicit sign bit.
+- `SQ31x32`: An alias for `SFixed<31, 32>`, a 64-bit signed fixed point in the Q31.32 format with implicit sign bit.
+- `SQ1x6`: An alias for `SFixed<1, 6>`, an 8-bit signed fixed point in the Q1.6 format with implicit sign bit.
+- `SQ1x14`: An alias for `SFixed<1, 14>`, a 16-bit signed fixed point in the Q1.14 format with implicit sign bit.
+- `SQ1x30`: An alias for `SFixed<1, 30>`, a 32-bit signed fixed point in the Q1.30 format with implicit sign bit.
+- `SQ1x62`: An alias for `SFixed<1, 62>`, a 64-bit signed fixed point in the Q1.62 format with implicit sign bit.
+
+([About Q Format](https://en.wikipedia.org/wiki/Q_(number_format)).)
+
+### Operators:
+
+- `+`: Adds two `UFixed`s or two `SFixed`s
+- `-`: Subtracts two `UFixed`s or two `SFixed`s
+- `*`: Multiplies two `UFixed`s or two `SFixed`s
+- `/`: Divides two `UFixed`s or two `SFixed`s
+- `==`: Compares two `UFixed`s or two `SFixed`s
+- `!=`: Compares two `UFixed`s or two `SFixed`s
+- `<`: Compares two `UFixed`s or two `SFixed`s
+- `<=`: Compares two `UFixed`s or two `SFixed`s
+- `>`: Compares two `UFixed`s or two `SFixed`s
+- `>=`: Compares two `UFixed`s or two `SFixed`s
+
+### Free Functions:
+
+- `floorFixed`: The floor operation.
+- `ceilFixed`: The Ceiling operation
+- `roundFixed`: Rounding operation.
+- `truncFixed`: Truncation operation.
+- `signbitFixed`: Returns `true` for signed numbers and `false` for unsigned numbers.
+- `copysignFixed`: Returns a value with the magnitude of the first argument and the sign of the second argument.
+- `multiply`: Multiplies two `UFixed`s or two `SFixed`s, returns a result that is twice the resolution of the input.
+
+### Member Functions:
+
+- `UFixed<I, F>::getInteger`: Gets the integer part of an unsigned fixed point.
+- `UFixed<I, F>::getFraction`: Gets the fractional part of an unsigned fixed point.
+- `UFixed<I, F>::getInternal`: Gets the internal representation of an unsigned fixed point.
+
+- `SFixed<I, F>::getInteger`: Gets the integer part of a signed fixed point.
+- `SFixed<I, F>::getFraction`: Gets the fractional part of a signed fixed point.
+- `SFixed<I, F>::getInternal`: Gets the internal representation of a signed fixed point.
+
+### Static Functions:
+
+- `UFixed<I, F>::fromInternal`: Produces an unsigned fixed point number from its internal representation.
+- `SFixed<I, F>::fromInternal`: Produces a signed fixed point number from its internal representation.
+
+## Construction:
+
+Note that both `UFixed<I, F>` and `SFixed<I, F>` are implicitly compile-time constructable from all integer and decimal literals.
+This means that you may write code such as `UFixed<8, 8> value = 0.5;` without incurring a runtime cost for converting from `double` to `UFixed<8, 8>` because the constructor is `constexpr`.
+
+`UFixed<I, F>` is constructable from:
+- Any integer literal type, regardless of sign.
+-- This constructs the fixed point as an integer with no fractional part.
+-- A value that does not fit shall be truncated without warning. 
+-- If a constant value is used, the fixed point shall be constructed at compile time.
+- An unsigned integer part and an unsigned fractional part.
+-- The integer part is of the smallest type capable of representing `I` bits.
+-- The fractional part is of the smallest type capable of representing `F` bits.
+-- If constant values are used, the fixed point shall be constructed at compile time.
+- Any decimal literal type, regardless of sign.
+-- This constructs the fixed point as a best approximation of the provided value.
+-- A value that does not fit shall be truncated without warning. 
+-- If a constant value is used, the fixed point shall be constructed at compile time.
+
+`SFixed<I, F>` is constructable from:
+- Any integer literal type, regardless of sign.
+-- This constructs the fixed point as an integer with no fractional part.
+-- A value that does not fit shall be truncated without warning. 
+-- If a constant value is used, the fixed point shall be constructed at compile time.
+- A signed integer part and an unsigned fractional part.
+-- The integer part is of the smallest type capable of representing `I + 1` bits.
+-- The fractional part is of the smallest type capable of representing `F` bits.
+-- If constant values are used, the fixed point shall be constructed at compile time.
+- Any decimal literal type, regardless of sign.
+-- This constructs the fixed point as a best approximation of the provided value.
+-- A value that does not fit shall be truncated without warning. 
+-- If a constant value is used, the fixed point shall be constructed at compile time.
+
+### Casts:
+
+`UFixed<I, F>` is explicitly convertible to:
+- `float`.
+- `double`.
+- The smallest unsigned type capable of holding its integer part. I.e. a type of at least `I` bits.
+- Another `UFixed` type of a different scale. E.g. `UFixed<4, 4>` may be converted to `UFixed<8, 8>` and vice versa.
+
+`SFixed<I, F>` is explicitly convertible to:
+- `float`.
+- `double`.
+- The smallest signed type capable of holding its integer part. I.e. a type of at least `I + 1` bits.
+- Another `SFixed` type of a different scale. E.g. `SFixed<3, 4>` may be converted to `SFixed<7, 8>` and vice versa.
+
+

--- a/Embedded/MaxMix/src/FixedPoints/Meta/library.json
+++ b/Embedded/MaxMix/src/FixedPoints/Meta/library.json
@@ -1,0 +1,18 @@
+{
+  "name": "FixedPoints",
+  "description": "A templated header-only fixed point arithmetic library aimed at Arduino",
+  "keywords": "maths, fixed, point, fixed point, arithmetic",
+  "authors":
+  {
+    "name": "Pharap",
+    "url": "https://github.com/Pharap"
+  },
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/Pharap/FixedPointsArduino.git"
+  },
+  "license": "Apache-2.0",
+  "version": "1.0.7",
+  "frameworks": "arduino"
+}

--- a/Embedded/MaxMix/src/FixedPoints/Meta/library.properties
+++ b/Embedded/MaxMix/src/FixedPoints/Meta/library.properties
@@ -1,0 +1,10 @@
+name=FixedPoints
+version=1.0.7
+author=Pharap
+maintainer=Pharap
+sentence=A template library for defining fixed point types of varying sizes.
+paragraph=The library is designed to be generic so it should be applicable to almost all size requirements and processor architectures.
+category=Data Processing
+url=https://github.com/Pharap/FixedPointsArduino
+architectures=*
+includes=FixedPoints.h, FixedPointsCommon.h

--- a/Embedded/MaxMix/src/FixedPoints/keywords.txt
+++ b/Embedded/MaxMix/src/FixedPoints/keywords.txt
@@ -1,0 +1,47 @@
+
+####################################
+# Syntax Colouring For FixedPoints #
+####################################
+
+####################################
+# Datatypes (KEYWORD1)             #
+####################################
+
+SFixed	KEYWORD1
+UFixed	KEYWORD1
+UQ4x4	KEYWORD1
+UQ8x8	KEYWORD1
+UQ16x16	KEYWORD1
+UQ32x32	KEYWORD1
+UQ1x7	KEYWORD1
+UQ1x15	KEYWORD1
+UQ1x31	KEYWORD1
+UQ1x63	KEYWORD1
+SQ3x4	KEYWORD1
+SQ7x8	KEYWORD1
+SQ15x16	KEYWORD1
+SQ31x32	KEYWORD1
+SQ1x6	KEYWORD1
+SQ1x14	KEYWORD1
+SQ1x30	KEYWORD1
+SQ1x62	KEYWORD1
+
+####################################
+# Methods and Functions (KEYWORD2) #
+####################################
+
+getInternal	KEYWORD2
+getInteger	KEYWORD2
+getFraction	KEYWORD2
+fromInternal	KEYWORD2
+multiply	KEYWORD2
+floorFixed	KEYWORD2
+ceilFixed	KEYWORD2
+roundFixed	KEYWORD2
+truncFixed	KEYWORD2
+signbitFixed	KEYWORD2
+absFixed	KEYWORD2
+copysignFixed	KEYWORD2
+nextafterFixed	KEYWORD2
+randomUFixed	KEYWORD2
+randomSFixed	KEYWORD2

--- a/LICENSES.md
+++ b/LICENSES.md
@@ -26,5 +26,6 @@ Maxmix dependencies and licences
 * Adafruit SSD1306 - BSD License : https://github.com/adafruit/Adafruit_SSD1306/blob/master/license.txt
 * Adafruit NeoPixel - BSD License : https://github.com/adafruit/Adafruit_NeoPixel/blob/master/license.txt
 * ButtonEvents - MIT License : https://github.com/fasteddy516/ButtonEvents/blob/master/LICENSE
+* FixedPoints - Apache 2 license : https://github.com/Pharap/FixedPointsArduino/blob/master/LICENSE
 * Rotary - GNU GPL Version 3 : https://github.com/brianlow/Rotary
 * TimerOne - Creative Commons Attribution 3.0 License : https://github.com/PaulStoffregen/TimerOne


### PR DESCRIPTION
## Issues
The volume acceleration calculation was using floating point numbers which is expensive to run on an atmega328.

## Description
Optimized the volume acceleration calculation using fixed points mathematics.
Added the https://github.com/Pharap/FixedPointsArduino library and used it to calculate the acceleration.
No more floating point numbers.

## Types of changes
- [x] Optimization
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] Requested changes are in a branch
- [x] Compiled and tested requested changes on target hardware (PC, device)
- [ ] Updated the documentation, if necessary
- [x] Updated the LICENSES file, if necessary
- [x] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository

