### PR TITLE
fix exception in discovery closing port

### DIFF
--- a/Desktop/Application/MaxMix/Services/Communication/Discovery/DiscoveryService.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Discovery/DiscoveryService.cs
@@ -97,13 +97,7 @@ namespace MaxMix.Services.Communication
 
                     Send(serialPort);
                 }
-                catch
-                {
-                    if(serialPort != null && serialPort.IsOpen)
-                        serialPort.Close();
-
-                    continue;
-                }
+                catch { continue; }
 
                 try
                 {


### PR DESCRIPTION
## Issues
 - Fixes #MAXMIX-G

## Description
Removed trying to close port in catch block if an exception was raised opening the port.
Closing the port is itself causing an exception which is uncaught.

## Types of changes
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Requested changes are in a branch
- [X] Compiled and tested requested changes on target hardware (PC, device)
- [X] Updated the documentation, if necessary
- [X] Updated the LICENSES file, if necessary
- [X] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
