### PR TITLE
Added ability to set double tap(click) speed from the desktop settings

### DIFF
--- a/Desktop/Application/MaxMix/App.config
+++ b/Desktop/Application/MaxMix/App.config
@@ -28,6 +28,9 @@
             <setting name="AccelerationPercentage" serializeAs="String">
                 <value>60</value>
             </setting>
+          <setting name="DoubleTapTime" serializeAs="String">
+            <value>150</value>
+          </setting>
         </MaxMix.Properties.Settings>
     </userSettings>
 </configuration>

--- a/Desktop/Application/MaxMix/Properties/Settings.Designer.cs
+++ b/Desktop/Application/MaxMix/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace MaxMix.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.5.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.7.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -92,6 +92,18 @@ namespace MaxMix.Properties {
             }
             set {
                 this["AccelerationPercentage"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("150")]
+        public ushort DoubleTapTime {
+            get {
+                return ((ushort)(this["DoubleTapTime"]));
+            }
+            set {
+                this["DoubleTapTime"] = value;
             }
         }
     }

--- a/Desktop/Application/MaxMix/Properties/Settings.settings
+++ b/Desktop/Application/MaxMix/Properties/Settings.settings
@@ -20,7 +20,7 @@
     <Setting Name="AccelerationPercentage" Type="System.UInt32" Scope="User">
       <Value Profile="(Default)">60</Value>
     </Setting>
-    <Setting Name="DoubleTapTime" Type="System.UInt32" Scope="User">
+    <Setting Name="DoubleTapTime" Type="System.UInt16" Scope="User">
       <Value Profile="(Default)">150</Value>
     </Setting>
   </Settings>

--- a/Desktop/Application/MaxMix/Properties/Settings.settings
+++ b/Desktop/Application/MaxMix/Properties/Settings.settings
@@ -20,5 +20,8 @@
     <Setting Name="AccelerationPercentage" Type="System.UInt32" Scope="User">
       <Value Profile="(Default)">60</Value>
     </Setting>
+    <Setting Name="DoubleTapTime" Type="System.UInt32" Scope="User">
+      <Value Profile="(Default)">150</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Desktop/Application/MaxMix/Services/Communication/Message/MessageSettings.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Message/MessageSettings.cs
@@ -9,13 +9,14 @@ namespace MaxMix.Services.Communication
     internal class MessageSettings : IMessage
     {
         #region Constructor
-        public MessageSettings(bool displayNewSession, bool sleepWhenInactive, int sleepAfterSeconds, bool continuousScroll, uint accelerationPercentage)
+        public MessageSettings(bool displayNewSession, bool sleepWhenInactive, int sleepAfterSeconds, bool continuousScroll, uint accelerationPercentage, ushort doubleTapTime)
         {
             _displayNewSession = displayNewSession;
             _sleepWhenInactive = sleepWhenInactive;
             _sleepAfterSeconds = sleepAfterSeconds;
             _continuousScroll = continuousScroll;
             _accelerationPercentage = accelerationPercentage;
+            _doubleTapTime = doubleTapTime;
         }
         #endregion
 
@@ -28,6 +29,7 @@ namespace MaxMix.Services.Communication
         public int _sleepAfterSeconds;
         public bool _continuousScroll;
         public uint _accelerationPercentage;
+        public ushort _doubleTapTime;
         #endregion
 
         #region Properties
@@ -36,6 +38,7 @@ namespace MaxMix.Services.Communication
         public int SleepAfterSeconds { get => _sleepAfterSeconds; }
         public bool ContinuousScroll { get => _continuousScroll; }
         public uint AccelerationPercentage { get => _accelerationPercentage; }
+        public ushort DoubleTapTime { get => _doubleTapTime; }
         #endregion
 
         #region Private Methods
@@ -52,6 +55,7 @@ namespace MaxMix.Services.Communication
         * SLEEPAFTERSECONDS         BYTE        1
         * CONTINUOUSSCROLL          BYTE        1
         * ACCELERATIONPERCENTAGE    BYTE        1
+        * DOUBLETAPTIME             USHORT      2
         * ---------------------------------------------------
         */
 
@@ -64,6 +68,7 @@ namespace MaxMix.Services.Communication
             result.Add(Convert.ToByte(SleepAfterSeconds));
             result.Add(Convert.ToByte(ContinuousScroll));
             result.Add(Convert.ToByte(AccelerationPercentage));
+            result.AddRange(BitConverter.GetBytes(DoubleTapTime));
 
             return result.ToArray();
         }

--- a/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
+++ b/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
@@ -171,7 +171,8 @@ namespace MaxMix.ViewModels
                                               _settingsViewModel.SleepWhenInactive,
                                               _settingsViewModel.SleepAfterSeconds,
                                               _settingsViewModel.ContinuousScroll,
-                                              _settingsViewModel.AccelerationPercentage);
+                                              _settingsViewModel.AccelerationPercentage,
+                                              _settingsViewModel.DoubleTapTime);
 
             _communicationService.Send(message);
             _audioSessionService.SetVisibleSystemSounds(_settingsViewModel.SystemSounds);

--- a/Desktop/Application/MaxMix/ViewModels/SettingsViewModel.cs
+++ b/Desktop/Application/MaxMix/ViewModels/SettingsViewModel.cs
@@ -115,6 +115,19 @@ namespace MaxMix.ViewModels
                 RaisePropertyChanged();
             }
         }
+
+        /// <summary>
+        /// Value used to detect a double click from the encoder switch.
+        /// </summary>
+        public ushort DoubleTapTime
+        {
+            get => _settings.DoubleTapTime;
+            set
+            {
+                _settings.DoubleTapTime = value;
+                RaisePropertyChanged();
+            }
+        }
         #endregion
 
         #region Commands

--- a/Desktop/Application/MaxMix/Views/SettingsView.xaml
+++ b/Desktop/Application/MaxMix/Views/SettingsView.xaml
@@ -19,6 +19,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <!-- DisplayNewSession -->
@@ -58,5 +59,13 @@
                             Foreground="{StaticResource Brush_White}"
                             Minimum="1" Maximum="100"
                             Value="{Binding AccelerationPercentage}" />
+
+        <!-- Double Tap Time -->
+        <Label Grid.Column="0" Grid.Row="6"
+               Content="Double Tap Time (ms)" />
+        <xctk:IntegerUpDown Grid.Column="1" Grid.Row="6"
+                            Foreground="{StaticResource Brush_White}"
+                            Minimum="1" Maximum="2000"
+                            Value="{Binding DoubleTapTime}" />
     </Grid>
 </UserControl>

--- a/Embedded/MaxMix/Commands.ino
+++ b/Embedded/MaxMix/Commands.ino
@@ -89,9 +89,8 @@ void UpdateSettingsCommand(uint8_t* packageBuffer, Settings* settings)
   settings->continuousScroll = packageBuffer[5];
   settings->accelerationPercentage = packageBuffer[6];
 
-  uint16_t dblTapTime = ((uint32_t)packageBuffer[7]) |
-                        ((uint32_t)packageBuffer[8] << 8);
-
+  uint16_t dblTapTime = ((uint16_t)packageBuffer[7]) |
+                        ((uint16_t)packageBuffer[8] << 8);
   encoderButton.doubleTapTime(dblTapTime);
 }
 

--- a/Embedded/MaxMix/Commands.ino
+++ b/Embedded/MaxMix/Commands.ino
@@ -88,6 +88,11 @@ void UpdateSettingsCommand(uint8_t* packageBuffer, Settings* settings)
   settings->sleepAfterSeconds = packageBuffer[4];
   settings->continuousScroll = packageBuffer[5];
   settings->accelerationPercentage = packageBuffer[6];
+
+  uint16_t dblTapTime = ((uint32_t)packageBuffer[7]) |
+                        ((uint32_t)packageBuffer[8] << 8);
+
+  encoderButton.doubleTapTime(dblTapTime);
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
## Issues
 - Fix #139 inability to set the double tap time on the encoder push switch.

## Description
Added a new settings which allow users to set the double tap time in milliseconds.


## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] Requested changes are in a branch
- [x] Compiled and tested requested changes on target hardware (PC, device)
