### PR TITLE
Try to not waste clicks or rotation

### DIFF
--- a/Embedded/MaxMix/MaxMix.ino
+++ b/Embedded/MaxMix/MaxMix.ino
@@ -441,10 +441,8 @@ bool ProcessEncoderButton()
     if(itemCount == 0 || stateDisplay == STATE_DISPLAY_SLEEP)
     {
       TimerDisplayReset();
-      return true;
     }
-    
-    if(mode == MODE_APPLICATION)
+    else if(mode == MODE_APPLICATION)
     {
       CycleApplicationState();
       TimerDisplayReset();
@@ -457,12 +455,8 @@ bool ProcessEncoderButton()
 
     return true;
   }
-  
-  if(encoderButton.doubleTapped())
+  else if(encoderButton.doubleTapped())
   {
-    if(itemCount == 0 || stateDisplay == STATE_DISPLAY_SLEEP)
-      return true;
-
     if(mode == MODE_MASTER)
       ToggleMute(itemIndexMaster);
 
@@ -474,12 +468,11 @@ bool ProcessEncoderButton()
 
     return true;
   }
-
-  if(encoderButton.held())
+  else if(encoderButton.held())
   {
     if(itemCount == 0 || stateDisplay == STATE_DISPLAY_SLEEP)
       return true;
-      
+
     CycleMode();
     TimerDisplayReset();
 

--- a/Embedded/MaxMix/MaxMix.ino
+++ b/Embedded/MaxMix/MaxMix.ino
@@ -384,6 +384,9 @@ bool ProcessEncoderRotation()
   uint32_t deltaTime = now - encoderLastTransition;
   encoderLastTransition = now;
 
+  if(itemCount == 0 || stateDisplay == STATE_DISPLAY_SLEEP)
+    return true;
+
   if(mode == MODE_MASTER)
   {
     items[0].volume = ComputeAcceleratedVolume(encoderDelta, deltaTime, items[0].volume);
@@ -396,7 +399,6 @@ bool ProcessEncoderRotation()
       itemIndexApp = GetNextIndex(itemIndexApp, itemCount, encoderDelta, settings.continuousScroll);
       TimerDisplayReset();
     }
-
     else if(stateApplication == STATE_APPLICATION_EDIT)
     {
       items[itemIndexApp].volume = ComputeAcceleratedVolume(encoderDelta, deltaTime, items[itemIndexApp].volume);
@@ -447,10 +449,6 @@ bool ProcessEncoderButton()
     else if(mode == MODE_GAME)
     {
       CycleGameState();
-      TimerDisplayReset();
-    }
-    else if(itemCount == 0 || stateDisplay == STATE_DISPLAY_SLEEP)
-    {
       TimerDisplayReset();
     }
 

--- a/Embedded/MaxMix/MaxMix.ino
+++ b/Embedded/MaxMix/MaxMix.ino
@@ -384,9 +384,6 @@ bool ProcessEncoderRotation()
   uint32_t deltaTime = now - encoderLastTransition;
   encoderLastTransition = now;
 
-  if(itemCount == 0 || stateDisplay == STATE_DISPLAY_SLEEP)
-    return true;
-
   if(mode == MODE_MASTER)
   {
     items[0].volume = ComputeAcceleratedVolume(encoderDelta, deltaTime, items[0].volume);
@@ -438,12 +435,6 @@ bool ProcessEncoderButton()
 {
   if(encoderButton.tapped())
   {
-    if(itemCount == 0 || stateDisplay == STATE_DISPLAY_SLEEP)
-    {
-      TimerDisplayReset();
-      return true;
-    }
-    
     if(mode == MODE_APPLICATION)
     {
       CycleApplicationState();
@@ -454,15 +445,15 @@ bool ProcessEncoderButton()
       CycleGameState();
       TimerDisplayReset();
     }
+    else if(itemCount == 0 || stateDisplay == STATE_DISPLAY_SLEEP)
+    {
+      TimerDisplayReset();
+    }
 
     return true;
   }
-  
-  if(encoderButton.doubleTapped())
+  else if(encoderButton.doubleTapped())
   {
-    if(itemCount == 0 || stateDisplay == STATE_DISPLAY_SLEEP)
-      return true;
-
     if(mode == MODE_MASTER)
       ToggleMute(itemIndexMaster);
 
@@ -474,12 +465,8 @@ bool ProcessEncoderButton()
 
     return true;
   }
-
-  if(encoderButton.held())
+  else if(encoderButton.held())
   {
-    if(itemCount == 0 || stateDisplay == STATE_DISPLAY_SLEEP)
-      return true;
-      
     CycleMode();
     TimerDisplayReset();
 


### PR DESCRIPTION
## Description
There was a little something which had been bugging me for a while : the first interaction on the knob was used to awake the display but no action was registered.  It meant that double clicking on the knob was ignored when the display was asleep. So I ended up having to do 2x double clicks to mute the currently selected item.

I changed it so we don't waste user inputs. Sometimes people want to interact with the device without looking at the LCD.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Requested changes are in a branch
- [x] Compiled and tested requested changes on target hardware (PC, device)

