### PR TITLE
Host crash detection/2 way ACK

### DIFF
--- a/Desktop/Application/MaxMix/Properties/AssemblyInfo.cs
+++ b/Desktop/Application/MaxMix/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.0.136")]
-[assembly: AssemblyFileVersion("0.0.0.136")]
+[assembly: AssemblyVersion("0.0.0.153")]
+[assembly: AssemblyFileVersion("0.0.0.153")]

--- a/Desktop/Application/MaxMix/Services/Communication/CommunicationService.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/CommunicationService.cs
@@ -107,7 +107,10 @@ namespace MaxMix.Services.Communication
                 {
                     try
                     {
-                        _waitingAck = true;
+                        if (message.GetType() != typeof(MessageAcknowledgment))
+                        {
+                            _waitingAck = true;
+                        }
 
                         var messageBytes = _serializationService.Serialize(message, _messageRevision);
                         _serialPort.Write(messageBytes, 0, messageBytes.Length);
@@ -228,13 +231,13 @@ namespace MaxMix.Services.Communication
                             if (message.GetType() == typeof(MessageAcknowledgment))
                             {
                                 MessageAcknowledgment ack = (MessageAcknowledgment)message;
-                                if (ack.Revision == _messageRevision)
+                                if (ack.GetRevision() == _messageRevision)
                                 {
-                                    Debug.WriteLine($"[CommunicationService] ACK received successfuly: {ack.Revision}");
+                                    Debug.WriteLine($"[CommunicationService] ACK received successfuly: {ack.GetRevision()}");
                                     _waitingAck = false;
                                 }
                                 else
-                                    RaiseError($"ACK revision error, received: {ack.Revision} expected: {_messageRevision}");
+                                    RaiseError($"ACK revision error, received: {ack.GetRevision()} expected: {_messageRevision}");
                             }
                             else
                                 RaiseMessageReceived(message);

--- a/Desktop/Application/MaxMix/Services/Communication/Message/IMessage.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Message/IMessage.cs
@@ -4,5 +4,7 @@
     {
         byte[] GetBytes();
         bool SetBytes(byte[] bytes);
+        byte GetRevision();
+        bool SetRevision(byte revision);
     }
 }

--- a/Desktop/Application/MaxMix/Services/Communication/Message/MessageAcknowledgment.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Message/MessageAcknowledgment.cs
@@ -9,9 +9,7 @@ namespace MaxMix.Services.Communication
     internal class MessageAcknowledgment : IMessage
     {
         #region Constructor
-        public MessageAcknowledgment(byte revision) {
-            _revision = revision;
-        }
+        public MessageAcknowledgment() {}
         #endregion
 
         #region Fields

--- a/Desktop/Application/MaxMix/Services/Communication/Message/MessageAcknowledgment.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Message/MessageAcknowledgment.cs
@@ -19,17 +19,26 @@ namespace MaxMix.Services.Communication
         #endregion
 
         #region Properties
-        public byte Revision { get => _revision; }
         #endregion
 
         #region Public Methods
         public byte[] GetBytes()
         {
-            throw new NotImplementedException("Should never be called");
+            return new byte[] {_revision};
         }
 
         public bool SetBytes(byte[] bytes)
         {
+            return true;
+        }
+
+        public byte GetRevision()
+        {
+            return _revision;
+        }
+        public bool SetRevision(byte revision)
+        {
+            _revision = revision;
             return true;
         }
         #endregion

--- a/Desktop/Application/MaxMix/Services/Communication/Message/MessageAddSession.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Message/MessageAddSession.cs
@@ -26,6 +26,7 @@ namespace MaxMix.Services.Communication
         #endregion
         
         #region Fields
+        private byte _revision;
         private int _id;
         private string _name;
         private string _encodedName;
@@ -89,6 +90,15 @@ namespace MaxMix.Services.Communication
         public bool SetBytes(byte[] bytes)
         {
             throw new NotImplementedException("Should never be called");
+        }
+        public byte GetRevision()
+        {
+            return _revision;
+        }
+        public bool SetRevision(byte revision)
+        {
+            _revision = revision;
+            return true;
         }
         #endregion
     }

--- a/Desktop/Application/MaxMix/Services/Communication/Message/MessageHandShakeRequest.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Message/MessageHandShakeRequest.cs
@@ -9,13 +9,14 @@ namespace MaxMix.Services.Communication
     internal class MessageHandShakeRequest : IMessage
     {
         #region Constructor
-        public MessageHandShakeRequest() { }
+        public MessageHandShakeRequest() {}
         #endregion
 
         #region Consts
         #endregion
 
         #region Fields
+        private byte _revision;
         #endregion
 
         #region Properties
@@ -30,6 +31,15 @@ namespace MaxMix.Services.Communication
         public bool SetBytes(byte[] bytes)
         {
             throw new NotImplementedException("Should never be called");
+        }
+        public byte GetRevision()
+        {
+            return _revision;
+        }
+        public bool SetRevision(byte revision)
+        {
+            _revision = revision;
+            return true;
         }
         #endregion
     }

--- a/Desktop/Application/MaxMix/Services/Communication/Message/MessageRemoveSession.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Message/MessageRemoveSession.cs
@@ -20,6 +20,7 @@ namespace MaxMix.Services.Communication
         #endregion
 
         #region Fields
+        private byte _revision;
         private int _id;
         private bool _isDevice;
         #endregion
@@ -56,6 +57,15 @@ namespace MaxMix.Services.Communication
         public bool SetBytes(byte[] bytes)
         {
             throw new NotImplementedException("Should never be called");
+        }
+        public byte GetRevision()
+        {
+            return _revision;
+        }
+        public bool SetRevision(byte revision)
+        {
+            _revision = revision;
+            return true;
         }
         #endregion
     }

--- a/Desktop/Application/MaxMix/Services/Communication/Message/MessageSettings.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Message/MessageSettings.cs
@@ -24,6 +24,7 @@ namespace MaxMix.Services.Communication
         #endregion
 
         #region Fields
+        private byte _revision;
         public bool _displayNewSession;
         public bool _sleepWhenInactive;
         public int _sleepAfterSeconds;
@@ -76,6 +77,15 @@ namespace MaxMix.Services.Communication
         public bool SetBytes(byte[] bytes)
         {
             throw new NotImplementedException("Should never be called");
+        }
+        public byte GetRevision()
+        {
+            return _revision;
+        }
+        public bool SetRevision(byte revision)
+        {
+            _revision = revision;
+            return true;
         }
         #endregion
     }

--- a/Desktop/Application/MaxMix/Services/Communication/Message/MessageUpdateVolumeSession.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Message/MessageUpdateVolumeSession.cs
@@ -24,6 +24,7 @@ namespace MaxMix.Services.Communication
         #endregion
 
         #region Fields
+        private byte _revision;
         private int _id;
         private int _volume;
         private bool _isMuted;
@@ -75,6 +76,15 @@ namespace MaxMix.Services.Communication
             _isMuted = Convert.ToBoolean(bytes[5]);
             _isDevice = false;
 
+            return true;
+        }
+        public byte GetRevision()
+        {
+            return _revision;
+        }
+        public bool SetRevision(byte revision)
+        {
+            _revision = revision;
             return true;
         }
         #endregion

--- a/Desktop/Application/MaxMix/Services/Communication/Serial/CobsSerializationService .cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Serial/CobsSerializationService .cs
@@ -214,11 +214,8 @@ namespace MaxMix.Services.Communication
                 // Message from an unregistered type, simply ignore it.
                 return null;
             }
-            else if (type == typeof(MessageAcknowledgment))
-            {
-                message = Activator.CreateInstance(type, revision) as MessageAcknowledgment;
-            }
-            else {
+            else
+            { 
                 message = Activator.CreateInstance(type) as IMessage;
             }
 

--- a/Desktop/Application/MaxMix/Services/Communication/Serial/CobsSerializationService .cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Serial/CobsSerializationService .cs
@@ -222,6 +222,7 @@ namespace MaxMix.Services.Communication
                 message = Activator.CreateInstance(type) as IMessage;
             }
 
+            message.SetRevision(revision);
             if (!message.SetBytes(payload))
                 throw new ArgumentException("Incorrect payload for message type.");
 

--- a/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
+++ b/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
@@ -175,6 +175,13 @@ namespace MaxMix.ViewModels
         {
             ExitRequested?.Invoke(this, EventArgs.Empty);
         }
+
+        private void SendAck(byte revision)
+        {
+            MessageAcknowledgment ack = new MessageAcknowledgment(revision);
+            Debug.WriteLine("Sending ACK: " + ack.GetRevision());
+            _communicationService.Send(ack);
+        }
         #endregion
 
         #region EventHandlers
@@ -237,6 +244,12 @@ namespace MaxMix.ViewModels
                 var message_ = message as MessageUpdateVolumeSession;
                 _audioSessionService.SetItemVolume(message_.Id, message_.Volume, message_.IsMuted);
             }
+
+            // Send ACK to device
+            SendAck(message.GetRevision());
+
+
+
         }
 
         private void OnCommunicationError(object sender, string e)

--- a/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
+++ b/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
@@ -180,7 +180,7 @@ namespace MaxMix.ViewModels
         {
             MessageAcknowledgment ack = new MessageAcknowledgment();
             ack.SetRevision(revision);
-            Debug.WriteLine("Sending ACK: " + ack.GetRevision());
+            Debug.WriteLine($"[MainViewModel] ACK sent. Revision: {revision}");
             _communicationService.Send(ack);
         }
         #endregion
@@ -248,9 +248,6 @@ namespace MaxMix.ViewModels
 
             // Send ACK to device
             SendAck(message.GetRevision());
-
-
-
         }
 
         private void OnCommunicationError(object sender, string e)

--- a/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
+++ b/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
@@ -178,7 +178,8 @@ namespace MaxMix.ViewModels
 
         private void SendAck(byte revision)
         {
-            MessageAcknowledgment ack = new MessageAcknowledgment(revision);
+            MessageAcknowledgment ack = new MessageAcknowledgment();
+            ack.SetRevision(revision);
             Debug.WriteLine("Sending ACK: " + ack.GetRevision());
             _communicationService.Send(ack);
         }

--- a/Embedded/MaxMix/Commands.ino
+++ b/Embedded/MaxMix/Commands.ino
@@ -25,9 +25,9 @@ void SendAcknowledgment(uint8_t* rawBuffer, uint8_t* packageBuffer, uint8_t revi
 
 //---------------------------------------------------------
 //---------------------------------------------------------
-void SendItemVolumeCommand(Item* item, uint8_t* rawBuffer, uint8_t* packageBuffer)
+void SendItemVolumeCommand(Item* item, uint8_t* rawBuffer, uint8_t* packageBuffer, bool *waitingAck, uint32_t* ackTimer, uint32_t now)
 {
-  rawBuffer[0] = packageRevision++;
+  rawBuffer[0] = ++messageRevision;
   rawBuffer[1] = MSG_COMMAND_UPDATE_VOLUME;
   
   rawBuffer[2] = (uint8_t)(item->id >> 24) & 0xFF;
@@ -38,8 +38,7 @@ void SendItemVolumeCommand(Item* item, uint8_t* rawBuffer, uint8_t* packageBuffe
   rawBuffer[6] = item->volume;
   rawBuffer[7] = item->isMuted;
   
-  uint8_t encodeSize =  EncodePackage(rawBuffer, 8, packageBuffer);
-  Serial.write(packageBuffer, encodeSize);
+  SendData(rawBuffer, packageBuffer, waitingAck, ackTimer, now);
 }
 
 //---------------------------------------------------------
@@ -132,4 +131,11 @@ bool GetIsDeviceFromRemovePackage(uint8_t* packageBuffer)
 bool GetIsDeviceFromUpdatePackage(uint8_t* packageBuffer)
 {
     return packageBuffer[8] > 0;
+}
+
+//---------------------------------------------------------
+//---------------------------------------------------------
+bool ProcessAcknowledgment(uint8_t* packageBuffer, uint8_t messageRevision)
+{
+    return (packageBuffer[2] == messageRevision);
 }

--- a/Embedded/MaxMix/Communication.ino
+++ b/Embedded/MaxMix/Communication.ino
@@ -33,6 +33,18 @@ bool ReceiveData(uint8_t* buffer, uint8_t* index, uint8_t delimiter, uint8_t buf
 }
 
 //---------------------------------------------------------
+//=
+//---------------------------------------------------------
+void SendData(uint8_t* rawBuffer, uint8_t* packageBuffer, bool* waitingAck, uint32_t* ackTimer, uint32_t now)
+{
+  uint8_t encodeSize =  EncodePackage(rawBuffer, 8, packageBuffer);
+  Serial.write(packageBuffer, encodeSize);
+
+  *waitingAck = true;
+  *ackTimer = now;
+}
+
+//---------------------------------------------------------
 // 
 //---------------------------------------------------------
 uint8_t EncodePackage(uint8_t* inBuffer, uint8_t size, uint8_t* outBuffer)

--- a/Embedded/MaxMix/Config.h
+++ b/Embedded/MaxMix/Config.h
@@ -70,6 +70,8 @@ static const uint8_t MSG_COMMAND_SETTINGS =  5;
 
 static const uint8_t MSG_PACKET_DELIMITER = 0;
 
+static const uint16_t ACK_TIMEOUT = 200; // in ms
+
 // --- Screen Drawing
 static const uint8_t DISPLAY_WIDTH = 128;
 static const uint8_t DISPLAY_HEIGHT = 32;


### PR DESCRIPTION
## Issues
 - Closes #128 

## Description
The device will now reset when the host stops responding (crashes). The device will be in a ready-to-connect state.

Rewritten message revisions to support 2-way ack and layout framework for future commands. 
Every message type now has a revision field (but not all are used)
Device's revision counter is separate from host's. The device expects its revision in the ACK msg, and the host expects its own revision.

The first byte of a packet, (both ways) is the **message revision of the sender**

On the Host, the way I have implemented this is that the _revision field in each message is the revision received by the host (sent by device) ie device>host packet. Altho there is currently only one message that is being sent from device>host, that is the VolumeUpdateMessage, I have written it so that any message can be sent/received and can hold the received revision.

## Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Requested changes are in a branch
- [X] Compiled and tested requested changes on target hardware (PC, device)
- [ ] Updated the documentation, if necessary
- [ ] Updated the LICENSES file, if necessary
- [X] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository

