### PR TITLE
Updated i2c comm to use 400k for oled updates making device more responsive

### DIFF
--- a/Embedded/MaxMix/Config.h
+++ b/Embedded/MaxMix/Config.h
@@ -46,6 +46,7 @@ static const uint8_t  STATE_DISPLAY_SLEEP = 1;
 
 // --- Display
 static const uint8_t  DISPLAY_RESET =   4; // Reset pin # (or -1 if sharing Arduino reset pin)
+static const uint32_t DISPLAY_SPEED =   400000;
 
 // --- Lighting
 static const uint8_t  PIXELS_NUM = 8; // Number of pixels in ring

--- a/Embedded/MaxMix/Display.ino
+++ b/Embedded/MaxMix/Display.ino
@@ -51,6 +51,7 @@ float GetTimerDisplayB()
 
 Adafruit_SSD1306* InitializeDisplay()
 {
+  Wire.setClock(DISPLAY_SPEED);
   Adafruit_SSD1306* display = new Adafruit_SSD1306(DISPLAY_WIDTH, DISPLAY_HEIGHT, &Wire, DISPLAY_RESET);
   display->begin(SSD1306_SWITCHCAPVCC, DISPLAY_ADDRESS);
   display->setRotation(2);


### PR DESCRIPTION
## Issues
 - Fixes (partially) #154 
 - Resolves #
 - Closes #

## Description
Arduino Wire library defaults to the slowest communication speed of 100k, to flush the OLED 128x32 buffer, this takes roughly 40ms at that speed. This is a simple change to the InitializeDisplay() function to up the communication speed to 400k which is known to work fairly well with the common OLED displays in use thanks to QMK's wide user base. This change alone decreases the flush time to 10ms and the device is noticeably more responsive as a result. There's still quite a few more changes that could be done still to make it even more responsive, but this is biggest low hanging fruit currently, thus it deserves it's own PR.

## Types of changes
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Requested changes are in a branch
- [x] Compiled and tested requested changes on target hardware (PC, device)
- [ ] Updated the documentation, if necessary
- [ ] Updated the LICENSES file, if necessary
- [x] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
