### PR TITLE
Some pretty led FXs

### DIFF
--- a/Embedded/MaxMix/Config.h
+++ b/Embedded/MaxMix/Config.h
@@ -48,7 +48,7 @@ static const uint8_t  STATE_DISPLAY_SLEEP = 1;
 static const uint8_t  DISPLAY_RESET =   4; // Reset pin # (or -1 if sharing Arduino reset pin)
 
 // --- Lighting
-static const uint8_t  PIXELS_NUM = 8; // Number of pixels in ring
+static const uint8_t  PIXELS_COUNT = 8; // Number of pixels in ring
 
 // --- Rotary Encoder
 static const uint16_t ROTARY_ACCELERATION_DIVISOR_MAX = 400;

--- a/Embedded/MaxMix/Lighting.ino
+++ b/Embedded/MaxMix/Lighting.ino
@@ -6,13 +6,100 @@
 // DECRIPTION:
 //********************************************************
 
-//********************************************************
-// *** FUNCTIONS
-//********************************************************
-void SetPixelsColor(Adafruit_NeoPixel* pixels, uint8_t r, uint8_t g, uint8_t b)
+//---------------------------------------------------------
+//---------------------------------------------------------
+void UpdateLighting()
 {
-  pixels->setPixelColor(0, pixels->Color(r, g, b)); // BACK
-  pixels->setPixelColor(3, pixels->Color(r, g, b)); // FRONT-RIGHT
-  pixels->setPixelColor(5, pixels->Color(r, g, b)); // FRONT-LEFT
+  if(stateDisplay == STATE_DISPLAY_SLEEP)
+  {
+    LightingBlackOut();
+  }
+  else if(sessionCount == 0)
+  {
+    LightingCircularFunk();
+  }
+  else if(mode == MODE_OUTPUT)
+  {
+    LightingVolume(&devices[itemIndexOutput]);
+  }
+  else if(mode == MODE_APPLICATION)
+  {
+    LightingVolume(&sessions[itemIndexApp]);
+  }
+  else if(mode == MODE_GAME)
+  {
+    LightingVolumeDual(&sessions[itemIndexGameA]);
+  }
+
+  // Push the colors to the pixels strip
   pixels->show();
+}
+
+//---------------------------------------------------------
+void LightingBlackOut()
+{
+  // All black
+  pixels->clear();
+}
+
+//---------------------------------------------------------
+void LightingCircularFunk()
+{
+  uint32_t t = millis();
+  uint16_t hue = t * 20;
+  uint32_t rgbColor = pixels->ColorHSV(hue);
+  uint16_t period = 500;
+
+  uint16_t startOffset = 0;
+  if ((t % period) > (period / 2))
+  {
+    startOffset = 1;
+  }
+
+  pixels->clear();
+  pixels->setPixelColor(startOffset, rgbColor);
+  pixels->setPixelColor(startOffset+2, rgbColor);
+  pixels->setPixelColor(startOffset+4, rgbColor);
+  pixels->setPixelColor(startOffset+6, rgbColor);
+}
+
+//---------------------------------------------------------
+void LightingVolume(Item * item)
+{
+  if (!item->isMuted)
+  {
+    // Circular lighting representing volume.
+    uint32_t volAcc = ((uint32_t)item->volume * 255 * PIXELS_COUNT) / 100;
+    for (int i=0; i<PIXELS_COUNT; i++)
+    {
+      uint32_t amp = min(volAcc, 255);
+      volAcc -= amp;
+      uint32_t color = (amp << 16) | (amp << 8) | amp;
+      pixels->setPixelColor(i, color);
+    }
+  }
+  else
+  {
+    // Red breathing.
+    // All vars need to be signed for the formula to work.
+    int32_t t = millis();
+    int32_t period = 500;
+    int32_t amp = (period - abs(t % (2*period) - period)) * 255 / period; // Triangular wave
+    uint32_t color = (amp << 16);
+    pixels->fill(color);
+  }
+}
+
+//---------------------------------------------------------
+void LightingVolumeDual(Item * item)
+{
+  // Circular lighting representing volume.
+  uint32_t volAcc = ((uint32_t)item->volume * 255 * PIXELS_COUNT) / 100;
+  for (int i=0; i<PIXELS_COUNT; i++)
+  {
+    uint32_t amp = min(volAcc, 255);
+    volAcc -= amp;
+    uint32_t color = (amp << 16) | (255 - amp);
+    pixels->setPixelColor(i, color);
+  }
 }


### PR DESCRIPTION
## Issues
 - Closes #129

## Description
Implemented more advanced lighting FX. Refresh is set at 30Hz to avoid using too much cycles.
The FX goes like this : 
- When disconnected/looking for connection. The led are changing hue very fast and blinkingaround the ring.
- When muted it's a slow red breath/pulse.
- When changing volume, the ring is progressively filled with white, proportional to the volume.
- When using game mode, it's like changing volume but with two colors (item A = red, item B = blue)

Keep in mind my ring is not attached to anything yet, just laying on my desk, so I have no idea where the "first" pixel is physically located on a normal device. Also I don't have the transparent or colored disc below the cap so some effect maybe too subtle.

We are now using ALL the pixels of the ring (before we used only 3).   For now I clamped the brightness to approx 20% (50 of 255).  So double check you have a call to setBrightness in MaxMix.ino or you may draw too much mA from the USB port.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] Requested changes are in a branch
- [x] Compiled and tested requested changes on target hardware (PC, device)
- [ ] Updated the documentation, if necessary
- [ ] Updated the LICENSES file, if necessary
- [x] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository
