### PR TITLE
Increased leds brigthness from 20% to 37%

### DIFF
--- a/Embedded/MaxMix/Config.h
+++ b/Embedded/MaxMix/Config.h
@@ -53,6 +53,7 @@ static const uint32_t DISPLAY_SPEED =   400000;
 
 // --- Lighting
 static const uint8_t  PIXELS_COUNT = 8; // Number of pixels in ring
+static const uint8_t  PIXELS_BRIGHTNESS = 96; // Master brightness of all the pixels. [0..255] Be carefull of the current draw on the USB port.
 
 // --- Rotary Encoder
 static const uint16_t ROTARY_ACCELERATION_DIVISOR_MAX = 400;

--- a/Embedded/MaxMix/MaxMix.ino
+++ b/Embedded/MaxMix/MaxMix.ino
@@ -128,7 +128,7 @@ void setup()
 
   //--- Pixels
   pixels = new Adafruit_NeoPixel(PIXELS_COUNT, PIN_PIXELS, NEO_GRB + NEO_KHZ800);
-  pixels->setBrightness(50); // approx 20%
+  pixels->setBrightness(96); // approx 37%
   pixels->begin();
   pixels->show();
 

--- a/Embedded/MaxMix/MaxMix.ino
+++ b/Embedded/MaxMix/MaxMix.ino
@@ -128,7 +128,7 @@ void setup()
 
   //--- Pixels
   pixels = new Adafruit_NeoPixel(PIXELS_COUNT, PIN_PIXELS, NEO_GRB + NEO_KHZ800);
-  pixels->setBrightness(96); // approx 37%
+  pixels->setBrightness(PIXELS_BRIGHTNESS);
   pixels->begin();
   pixels->show();
 


### PR DESCRIPTION
## Issues
Leds are too dim.

## Description
Increased leds brigthness from 20% to 37%. Done via config.h

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] Requested changes are in a branch
- [x] Compiled and tested requested changes on target hardware (PC, device)
- [ ] Updated the documentation, if necessary
- [ ] Updated the LICENSES file, if necessary
- [x] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository
