### PR TITLE
New output mode

### DIFF
--- a/Desktop/Application/MaxMix/MaxMix.csproj
+++ b/Desktop/Application/MaxMix/MaxMix.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Services\Audio\IAudioDevice.cs" />
     <Compile Include="Services\Audio\IAudioSession.cs" />
     <Compile Include="Services\Audio\IAudioSessionService.cs" />
+    <Compile Include="Services\Communication\Message\MessageSetDefaultEndpoint.cs" />
     <Compile Include="Services\Communication\Serial\CobsSerializationService .cs" />
     <Compile Include="Services\Communication\CommunicationService.cs" />
     <Compile Include="Services\Communication\ICommunicationService.cs" />

--- a/Desktop/Application/MaxMix/Services/Audio/AudioSessionService.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioSessionService.cs
@@ -104,6 +104,10 @@ namespace MaxMix.Services.Audio
 
         public void SetDefaultEndpoint(int id)
         {
+            if (_devices.TryGetValue(id, out var device))
+            {
+                AudioExtensions.SetDefaultEndpoint(device.Device.DeviceID, Role.Multimedia);
+            }
 
         }
         #endregion

--- a/Desktop/Application/MaxMix/Services/Audio/AudioSessionService.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioSessionService.cs
@@ -101,6 +101,11 @@ namespace MaxMix.Services.Audio
                 // TODO: Raise error
             }
         }
+
+        public void SetDefaultEndpoint(int id)
+        {
+
+        }
         #endregion
 
         #region Private Methods

--- a/Desktop/Application/MaxMix/Services/Audio/IAudioSessionService.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/IAudioSessionService.cs
@@ -7,6 +7,7 @@ namespace MaxMix.Services.Audio
         void Start();
         void Stop();
         void SetItemVolume(int id, int volume, bool isMuted);
+        void SetDefaultEndpoint(int id);
 
         event DefaultAudioDeviceChangedDelegate DefaultDeviceChanged;
         event AudioDeviceCreatedDelegate DeviceCreated;

--- a/Desktop/Application/MaxMix/Services/Communication/Message/MessageSetDefaultEndpoint.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Message/MessageSetDefaultEndpoint.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MaxMix.Services.Communication
+{
+    internal class MessageSetDefaultEndpoint : IMessage
+    {
+        #region Constructor
+        public MessageSetDefaultEndpoint() { }
+        public MessageSetDefaultEndpoint(int id)
+        {
+            _id = id;
+        }
+        #endregion
+
+        #region Consts
+        #endregion
+
+        #region Fields
+        private int _id;
+        #endregion
+
+        #region Properties
+        public int Id { get => _id; }
+        #endregion
+
+        #region Private Methods
+        #endregion
+
+        #region Public Methods
+
+        /*
+        * ---------------------------------------
+        * CHUNK        TYPE        SIZE (BYTES)
+        * ---------------------------------------
+        * ID           INT32       4
+        * ---------------------------------------
+        *                          4
+        */
+
+        public byte[] GetBytes()
+        {
+            var result = new List<byte>();           
+            result.AddRange(BitConverter.GetBytes(Id));
+            return result.ToArray();
+        }
+
+        public bool SetBytes(byte[] bytes)
+        {
+            var idBytes = bytes.Take(4).Reverse().ToArray();
+            _id = BitConverter.ToInt32(idBytes, 0);
+            return true;
+        }
+        #endregion
+    }
+}

--- a/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
+++ b/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
@@ -33,7 +33,8 @@ namespace MaxMix.ViewModels
             _serializationService.RegisterType<MessageAddSession>(2);
             _serializationService.RegisterType<MessageRemoveSession>(3);
             _serializationService.RegisterType<MessageUpdateVolumeSession>(4);
-            _serializationService.RegisterType<MessageSettings>(5);
+            _serializationService.RegisterType<MessageSetDefaultEndpoint>(5);
+            _serializationService.RegisterType<MessageSettings>(6);
 
             _settingsViewModel = new SettingsViewModel();
             _settingsViewModel.PropertyChanged += OnSettingsChanged;
@@ -236,6 +237,11 @@ namespace MaxMix.ViewModels
             {
                 var message_ = message as MessageUpdateVolumeSession;
                 _audioSessionService.SetItemVolume(message_.Id, message_.Volume, message_.IsMuted);
+            }
+            else if (message.GetType() == typeof(MessageSetDefaultEndpoint))
+            {
+                var message_ = message as MessageSetDefaultEndpoint;
+                _audioSessionService.SetDefaultEndpoint(message_.Id);
             }
         }
 

--- a/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
+++ b/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
@@ -181,6 +181,8 @@ namespace MaxMix.ViewModels
         #region EventHandlers
         private void OnDefaultDeviceChanged(object sender, int id)
         {
+            var message = new MessageSetDefaultEndpoint(id);
+            _communicationService.Send(message);
         }
 
         private void OnDeviceCreated(object sender, int id, string displayName, int volume, bool isMuted)

--- a/Embedded/MaxMix/Commands.ino
+++ b/Embedded/MaxMix/Commands.ino
@@ -98,13 +98,6 @@ void UpdateItemVolumeCommand(uint8_t* packageBuffer, Item* itemsBuffer, uint8_t 
 
 //---------------------------------------------------------
 //---------------------------------------------------------
-void SetDefaultEndpointCommand(uint8_t* packageBuffer, Item* itemsBuffer, uint8_t index) 
-{
-  
-}
-
-//---------------------------------------------------------
-//---------------------------------------------------------
 void UpdateSettingsCommand(uint8_t* packageBuffer, Settings* settings) 
 {
   settings->displayNewItem = packageBuffer[2];

--- a/Embedded/MaxMix/Commands.ino
+++ b/Embedded/MaxMix/Commands.ino
@@ -44,6 +44,23 @@ void SendItemVolumeCommand(Item* item, uint8_t* rawBuffer, uint8_t* packageBuffe
 
 //---------------------------------------------------------
 //---------------------------------------------------------
+void SendSetDefaultEndpointCommand(Item* item, uint8_t* rawBuffer, uint8_t* packageBuffer)
+{
+  rawBuffer[0] = packageRevision++;
+  rawBuffer[1] = MSG_COMMAND_SET_DEFAULT_ENDPOINT;
+  
+  rawBuffer[2] = (uint8_t)(item->id >> 24) & 0xFF;
+  rawBuffer[3] = (uint8_t)(item->id >> 16) & 0xFF;
+  rawBuffer[4] = (uint8_t)(item->id >> 8) & 0xFF;
+  rawBuffer[5] = (uint8_t)item->id & 0xFF;
+ 
+  uint8_t encodeSize =  EncodePackage(rawBuffer, 8, packageBuffer);
+  Serial.write(packageBuffer, encodeSize);
+}
+
+
+//---------------------------------------------------------
+//---------------------------------------------------------
 void AddItemCommand(uint8_t* packageBuffer, Item* itemsBuffer, uint8_t* itemCount)
 {
   UpdateItemCommand(packageBuffer, itemsBuffer, *itemCount);
@@ -75,8 +92,15 @@ void RemoveItemCommand(uint8_t* packageBuffer, Item* itemsBuffer, uint8_t* itemC
 //---------------------------------------------------------
 void UpdateItemVolumeCommand(uint8_t* packageBuffer, Item* itemsBuffer, uint8_t index) 
 {
-    itemsBuffer[index].volume = packageBuffer[6];
-    itemsBuffer[index].isMuted = packageBuffer[7];
+  itemsBuffer[index].volume = packageBuffer[6];
+  itemsBuffer[index].isMuted = packageBuffer[7];
+}
+
+//---------------------------------------------------------
+//---------------------------------------------------------
+void SetDefaultEndpointCommand(uint8_t* packageBuffer, Item* itemsBuffer, uint8_t index) 
+{
+  
 }
 
 //---------------------------------------------------------

--- a/Embedded/MaxMix/Config.h
+++ b/Embedded/MaxMix/Config.h
@@ -71,7 +71,8 @@ static const uint8_t MSG_COMMAND_ACKNOWLEDGMENT =  1;
 static const uint8_t MSG_COMMAND_ADD =  2;
 static const uint8_t MSG_COMMAND_REMOVE =  3;
 static const uint8_t MSG_COMMAND_UPDATE_VOLUME =  4;
-static const uint8_t MSG_COMMAND_SETTINGS =  5;
+static const uint8_t MSG_COMMAND_SET_DEFAULT_ENDPOINT =  5;
+static const uint8_t MSG_COMMAND_SETTINGS =  6;
 
 static const uint8_t MSG_PACKET_DELIMITER = 0;
 

--- a/Embedded/MaxMix/Display.ino
+++ b/Embedded/MaxMix/Display.ino
@@ -168,7 +168,7 @@ void DrawSelectionItemVolume(Adafruit_SSD1306* display, uint8_t volume)
 //---------------------------------------------------------
 // Draws the output mode screen
 //---------------------------------------------------------
-void DisplayOutputSelectScreen(Adafruit_SSD1306* display, char* name, uint8_t volume, bool isMuted, uint8_t leftArrow, uint8_t rightArrow, uint8_t modeIndex, uint8_t modeCount)
+void DisplayOutputSelectScreen(Adafruit_SSD1306* display, char* name, uint8_t volume, bool isMuted, bool isDefaultEndpoint, uint8_t leftArrow, uint8_t rightArrow, uint8_t modeIndex, uint8_t modeCount)
 {
   display->clearDisplay();
 
@@ -178,6 +178,9 @@ void DisplayOutputSelectScreen(Adafruit_SSD1306* display, char* name, uint8_t vo
   display->fillRect(DISPLAY_WIDTH - DISPLAY_AREA_CENTER_MARGIN_SIDE, 0, DISPLAY_AREA_CENTER_MARGIN_SIDE, DISPLAY_CHAR_HEIGHT_X2, BLACK);
   DrawSelectionArrows(display, leftArrow, rightArrow);
   DrawSelectionVolumeBar(display, volume, isMuted);
+
+  if(isDefaultEndpoint)
+    DrawSelectionChannelName(display, "O");
 
   display->display();
 }

--- a/Embedded/MaxMix/Display.ino
+++ b/Embedded/MaxMix/Display.ino
@@ -147,6 +147,24 @@ void DrawSelectionVolumeBar(Adafruit_SSD1306* display, uint8_t volume, bool isMu
   display->drawLine(x0, y0, x0, y1, WHITE);
 }
 
+void DrawSelectionItemVolume(Adafruit_SSD1306* display, uint8_t volume)
+{
+  uint8_t x0;
+
+  if( volume < 10)
+    x0 = DISPLAY_AREA_CENTER_MARGIN_SIDE + DISPLAY_AREA_CENTER_WIDTH - DISPLAY_CHAR_WIDTH_X2;
+  else if(volume < 100)
+    x0 = DISPLAY_AREA_CENTER_MARGIN_SIDE + DISPLAY_AREA_CENTER_WIDTH - DISPLAY_CHAR_WIDTH_X2 * 2 - DISPLAY_CHAR_SPACING_X2 * 2;
+  else if(volume == 100)
+    x0 = DISPLAY_AREA_CENTER_MARGIN_SIDE + DISPLAY_AREA_CENTER_WIDTH - DISPLAY_CHAR_WIDTH_X2 * 3 - DISPLAY_CHAR_SPACING_X2 * 3;
+
+  display->setTextSize(2);
+  display->setTextColor(WHITE);
+  display->setCursor(x0, 0);
+  
+  display->print(volume);
+}
+
 //---------------------------------------------------------
 // Draws the output mode screen
 //---------------------------------------------------------
@@ -167,15 +185,12 @@ void DisplayOutputSelectScreen(Adafruit_SSD1306* display, char* name, uint8_t vo
 void DisplayOutputEditScreen(Adafruit_SSD1306* display, char* name, uint8_t volume, bool isMuted, uint8_t modeIndex, uint8_t modeCount)
 {
   display->clearDisplay();
-  
-  DrawDotGroup(display, modeIndex, modeCount);
-  DrawItemName(display, name, 1, DISPLAY_CHAR_WIDTH_X1, DISPLAY_CHAR_HEIGHT_X1, DISPLAY_CHAR_SPACING_X1, DISPLAY_AREA_CENTER_MARGIN_SIDE, 0, GetTimerDisplayA, ResetTimerDisplayA, DISPLAY_SCROLL_SPEED_X1);
-  // Clear sides
-  display->fillRect(0, 0, DISPLAY_AREA_CENTER_MARGIN_SIDE, DISPLAY_CHAR_HEIGHT_X1, BLACK);
-  display->fillRect(DISPLAY_WIDTH - DISPLAY_AREA_CENTER_MARGIN_SIDE, 0, DISPLAY_AREA_CENTER_MARGIN_SIDE, DISPLAY_CHAR_HEIGHT_X1, BLACK);
 
-  DrawEditVolumeBar(display, volume, isMuted);
-  DrawEditVolume(display, volume);
+  DrawDotGroup(display, modeIndex, modeCount);
+  DrawItemName(display, "VOL", 2, DISPLAY_CHAR_WIDTH_X2, DISPLAY_CHAR_HEIGHT_X2, DISPLAY_CHAR_SPACING_X2, DISPLAY_AREA_CENTER_MARGIN_SIDE, 0, GetTimerDisplayA, ResetTimerDisplayA, DISPLAY_SCROLL_SPEED_X2);
+  DrawSelectionItemVolume(display, volume);
+  DrawSelectionVolumeBar(display, volume, isMuted);
+
   display->display();
 }
 

--- a/Embedded/MaxMix/MaxMix.ino
+++ b/Embedded/MaxMix/MaxMix.ino
@@ -526,6 +526,9 @@ bool ProcessEncoderButton()
 
     if(mode == MODE_OUTPUT)
     {
+      if(stateOutput == STATE_OUTPUT_NAVIGATE)
+        SendSetDefaultEndpointCommand(&devices[itemIndexOutput], sendBuffer, encodeBuffer);
+
       stateOutput = CycleState(stateOutput, STATE_OUTPUT_COUNT);
       TimerDisplayReset();
     }

--- a/Embedded/MaxMix/MaxMix.ino
+++ b/Embedded/MaxMix/MaxMix.ino
@@ -82,6 +82,8 @@ int8_t itemIndexApp = 0;
 int8_t itemIndexGameA = 0;
 int8_t itemIndexGameB = 0;
 
+uint32_t defaultEndpointId;
+
 // Settings
 struct Settings settings;
 
@@ -389,6 +391,19 @@ bool ProcessPackage()
       return false;
     }    
   }
+  else if(command == MSG_COMMAND_SET_DEFAULT_ENDPOINT)
+  {
+    uint32_t id = GetIdFromPackage(decodeBuffer);
+    int8_t index = FindItem(id, devices, deviceCount);
+    if(index == -1)
+        return false;
+
+    itemIndexOutput = index;
+    defaultEndpointId = id;
+
+    if(mode == MODE_OUTPUT)
+      return true;
+  }
   else if(command == MSG_COMMAND_SETTINGS)
   {
     UpdateSettingsCommand(decodeBuffer, &settings);
@@ -655,7 +670,9 @@ void UpdateDisplay()
     {
       uint8_t scrollLeft = CanScrollLeft(itemIndexOutput, deviceCount, settings.continuousScroll);
       uint8_t scrollRight = CanScrollRight(itemIndexOutput, deviceCount, settings.continuousScroll);
-      DisplayOutputSelectScreen(display, devices[itemIndexOutput].name, devices[itemIndexOutput].volume, devices[itemIndexOutput].isMuted, scrollLeft, scrollRight, mode, MODE_COUNT);
+      uint8_t isDefaultEndpoint =  devices[itemIndexOutput].id == defaultEndpointId;
+
+      DisplayOutputSelectScreen(display, devices[itemIndexOutput].name, devices[itemIndexOutput].volume, devices[itemIndexOutput].isMuted, isDefaultEndpoint, scrollLeft, scrollRight, mode, MODE_COUNT);
     }
     else if(stateOutput == STATE_OUTPUT_EDIT)
       DisplayOutputEditScreen(display, devices[itemIndexOutput].name, devices[itemIndexOutput].volume, devices[itemIndexOutput].isMuted, mode, MODE_COUNT);

--- a/Embedded/MaxMix/MaxMix.ino
+++ b/Embedded/MaxMix/MaxMix.ino
@@ -66,7 +66,7 @@ uint8_t encodeBuffer[SEND_BUFFER_SIZE];
 
 // State
 uint8_t mode = MODE_OUTPUT;
-uint8_t stateOutput = STATE_OUTPUT_NAVIGATE;
+uint8_t stateOutput = STATE_OUTPUT_EDIT;
 uint8_t stateApplication = STATE_APPLICATION_NAVIGATE;
 uint8_t stateGame = STATE_GAME_SELECT_A;
 uint8_t stateDisplay = STATE_DISPLAY_AWAKE;
@@ -223,7 +223,7 @@ void ClearSend()
 void ResetState()
 {
   mode = MODE_OUTPUT;
-  stateOutput = STATE_OUTPUT_NAVIGATE;
+  stateOutput = STATE_OUTPUT_EDIT;
   stateApplication = STATE_APPLICATION_NAVIGATE;
   stateGame = STATE_GAME_SELECT_A;
   stateDisplay = STATE_DISPLAY_AWAKE;
@@ -268,15 +268,6 @@ bool ProcessPackage()
       }
       else
         UpdateItemCommand(decodeBuffer, devices, index);
-
-      if(settings.displayNewItem)
-      {
-        itemIndexOutput = index;
-        if(mode == MODE_OUTPUT)
-          stateOutput = STATE_OUTPUT_NAVIGATE;
-
-        return true;
-      }
     }
     else
     {


### PR DESCRIPTION
## Issues

## Description
Implemented new output mode based on feedback from @quadbyte and @XScorpion2 .
I got rid of the functionality to adjust the volume of different devices independently since it was over complicating the user experience in the device for a use case that may not be very common or even existent.

The new version brings back the simplified master volume edit screen and adds device switching to it.
Tapping once takes you to device selection mode, tapping once will switch to that output device and take you back to the volume edit screen.

## Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Requested changes are in a branch
- [X] Compiled and tested requested changes on target hardware (PC, device)
- [X] Updated the documentation, if necessary
- [X] Updated the LICENSES file, if necessary
- [X] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
