### PR TITLE
Implemented IPolicyConfig interface for set default device

### DIFF
--- a/Desktop/Application/MaxMix/MaxMix.csproj
+++ b/Desktop/Application/MaxMix/MaxMix.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Services\Communication\Message\MessageRemoveSession.cs" />
     <Compile Include="Services\Communication\Message\MessageSettings.cs" />
     <Compile Include="Services\Communication\Message\MessageUpdateVolumeSession.cs" />
+    <Compile Include="Services\Audio\PolicyConfig.cs" />
     <Compile Include="ViewModels\BaseViewModel.cs" />
     <Compile Include="ViewModels\MainViewModel.cs" />
     <Compile Include="ViewModels\SettingsViewModel.cs" />

--- a/Desktop/Application/MaxMix/Services/Audio/AudioExtensions.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using CSCore.CoreAudioAPI;
+using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -32,6 +33,12 @@ namespace MaxMix.Services.Audio
             if (string.IsNullOrEmpty(fileName)) return null;
             var versionInfo = FileVersionInfo.GetVersionInfo(fileName);
             return versionInfo.ProductName;
+        }
+
+        public static void SetDefaultEndpoint(string deviceID, Role role)
+        {
+            var policyConfig = new PolicyConfig();
+            policyConfig.SetDefaultEndpoint(deviceID, role);
         }
     }
 }

--- a/Desktop/Application/MaxMix/Services/Audio/PolicyConfig.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/PolicyConfig.cs
@@ -1,0 +1,55 @@
+﻿using CSCore.CoreAudioAPI;
+using CSCore.Win32;
+using System;
+using System.Runtime.InteropServices;
+
+namespace MaxMix.Services.Audio
+{
+    [Guid("8F9FB2AA-1C0B-4D54-B6BB-B2F2A10CE03C")]
+    class PolicyConfig : ComObject
+    {
+        public PolicyConfig() : base(CreatePolicyConfig()) { }
+
+        private static IntPtr CreatePolicyConfig()
+        {
+            var obj = new PolicyConfigObject();
+            if (obj is IPolicyConfig c)
+                return Marshal.GetComInterfaceForObject(c, typeof(IPolicyConfig));
+            throw new NotSupportedException("Unable to create PolicyConfig on this OS.");
+        }
+
+        public void SetDefaultEndpoint(string id, Role role)
+        {
+            var obj = Marshal.GetObjectForIUnknown(BasePtr);
+            int result = unchecked((int)0x80090011); // Object not found error
+            if (obj is IPolicyConfig c)
+                result = c.SetDefaultEndpoint(id, role);
+            Marshal.ThrowExceptionForHR(result);
+        }
+
+        [ComImport]
+        [Guid("870AF99C-171D-4F9E-AF0D-E63DF40C2BC9")]
+        private class PolicyConfigObject
+        {
+        }
+    }
+
+    [ComImport]
+    [Guid("F8679F50-850A-41CF-9C72-430F290290C8")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IPolicyConfig : IUnknown
+    {
+        void Unused1();
+        void Unused2();
+        void Unused3();
+        void Unused4();
+        void Unused5();
+        void Unused6();
+        void Unused7();
+        void Unused8();
+        void Unused9();
+        void Unused10();
+        int SetDefaultEndpoint([In, MarshalAs(UnmanagedType.LPWStr)] string id, Role role);
+        void Unused12();
+    }
+}


### PR DESCRIPTION
## Issues
 - Fixes #
 - Resolves #
 - Closes #

## Description
API support for switching the default device. The interface for doing this has changed at least 3 times between Windows vista and Windows 10, the current implementation is the one currently in used by Windows 10 and backwards compatible with Windows 7.

## Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Requested changes are in a branch
- [x] Compiled and tested requested changes on target hardware (PC, device)
- [ ] Updated the documentation, if necessary
- [ ] Updated the LICENSES file, if necessary
- [x] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
