### PR TITLE
Added null check for dispose

### DIFF
--- a/Desktop/Application/MaxMix/Services/Audio/AudioSession.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioSession.cs
@@ -151,10 +151,13 @@ namespace MaxMix.Services.Audio
         #region IDisposable
         public void Dispose()
         {
-            _events.StateChanged -= OnStateChanged;
-            _events.SimpleVolumeChanged -= OnVolumeChanged;
+            if (_events != null)
+            {
+                _events.StateChanged -= OnStateChanged;
+                _events.SimpleVolumeChanged -= OnVolumeChanged;
 
-            Session.UnregisterAudioSessionNotification(_events);
+                Session.UnregisterAudioSessionNotification(_events);
+            }
             Session = null;
             _session2 = null;
             _simpleAudio = null;


### PR DESCRIPTION
## Issues
 - Fixes #MAXMIX-Q
 - Resolves #
 - Closes #

## Description
Check if _events is null before attempting to UnregisterAudioSessionNotification

## Types of changes
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Requested changes are in a branch
- [X] Compiled and tested requested changes on target hardware (PC, device)
- [ ] Updated the documentation, if necessary
- [ ] Updated the LICENSES file, if necessary
- [X] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
