### PR TITLE
Adding new info state and screen to splash mode

### DIFF
--- a/BuildSystem/scripts/build-all.cmd
+++ b/BuildSystem/scripts/build-all.cmd
@@ -17,11 +17,11 @@ rmdir /s /q %RELEASE_DIR%
 mkdir %RELEASE_DIR%
 
 rmdir /s /q %BUILD_DIR%
-arduino-cli compile -b arduino:avr:nano:cpu=atmega328 -v --build-path %BUILD_DIR% %MAIN_INO%
+arduino-cli compile -b arduino:avr:nano:cpu=atmega328 -v --build-path %BUILD_DIR% "build.extra_flags=-DVERSION_MAJOR=9 -DVERSION_MINOR=9 -DVERSION_PATCH=9" %MAIN_INO%
 move %BUILD_DIR%\MaxMix.ino.hex %RELEASE_DIR%\MaxMix.ino.hex 
 
 rmdir /s /q  %BUILD_DIR%
-arduino-cli compile -b arduino:avr:nano:cpu=atmega328 -v --build-path %BUILD_DIR% --build-properties build.extra_flags=-DHALF_STEP %MAIN_INO%
+arduino-cli compile -b arduino:avr:nano:cpu=atmega328 -v --build-path %BUILD_DIR% --build-properties "build.extra_flags=-DHALF_STEP -DVERSION_MAJOR=9 -DVERSION_MINOR=9 -DVERSION_PATCH=9" %MAIN_INO%
 move %BUILD_DIR%\MaxMix.ino.hex %RELEASE_DIR%\MaxMix.halfstep.ino.hex 
 
 rmdir /s /q %BUILD_DIR%

--- a/Embedded/MaxMix/Config.h
+++ b/Embedded/MaxMix/Config.h
@@ -14,6 +14,22 @@
 #include "src/FixedPoints/FixedPointsCommon.h"
 
 //********************************************************
+// *** DEFINES
+//********************************************************
+#ifndef VERSION_MAJOR
+    #define VERSION_MAJOR 0
+#endif
+
+#ifndef VERSION_MINOR
+    #define VERSION_MINOR 0
+#endif
+
+#ifndef VERSION_PATCH
+    #define VERSION_PATCH 0
+#endif
+
+
+//********************************************************
 // *** CONSTS
 //********************************************************
 
@@ -27,10 +43,16 @@ static const uint8_t  PIN_ENCODER_OUTB = 16; //A2
 static const uint8_t  PIN_ENCODER_SWITCH = 17; //A3
 
 // --- States
+static const uint8_t  MODE_SPLASH = 255;
+
 static const uint8_t  MODE_OUTPUT = 0;
 static const uint8_t  MODE_APPLICATION = 1;
 static const uint8_t  MODE_GAME = 2;
 static const uint8_t  MODE_COUNT = 3;
+
+static const uint8_t  STATE_SPLASH_LOGO = 0;
+static const uint8_t  STATE_SPLASH_INFO = 1;
+static const uint8_t  STATE_SPLASH_COUNT = 2;
 
 static const uint8_t  STATE_OUTPUT_NAVIGATE = 0;
 static const uint8_t  STATE_OUTPUT_EDIT = 1;

--- a/Embedded/MaxMix/Display.cpp
+++ b/Embedded/MaxMix/Display.cpp
@@ -196,12 +196,36 @@ namespace Display
     }
 
     //---------------------------------------------------------
-    // MaxMix Logo Screen
+    // MaxMix Logo screen
     //---------------------------------------------------------
     void SplashScreen(void)
     {
         display.clearDisplay();
         display.drawBitmap(0, 0, LOGOBMP, LOGO_WIDTH, LOGO_HEIGHT, 1);
+        display.display();
+    }
+
+    //---------------------------------------------------------
+    // Firmware Version screen
+    //---------------------------------------------------------
+    void InfoScreen(void)
+    {
+        display.clearDisplay();
+
+        display.setTextColor(WHITE);
+        display.setTextSize(1);
+        
+        display.setCursor(0, (DISPLAY_HEIGHT / 2) - DISPLAY_CHAR_HEIGHT_X1);
+        display.print("FW: ");
+        display.print(VERSION_MAJOR);
+        display.print(".");
+        display.print(VERSION_MINOR);
+        display.print(".");
+        display.print(VERSION_PATCH);
+
+        display.setCursor(0, (DISPLAY_HEIGHT / 2) + DISPLAY_CHAR_SPACING_X2);
+        display.print("Built " __DATE__);
+
         display.display();
     }
 

--- a/Embedded/MaxMix/Display.h
+++ b/Embedded/MaxMix/Display.h
@@ -16,6 +16,7 @@ namespace Display
     void Sleep(void);
     
     void SplashScreen(void);
+    void InfoScreen(void);
     
     void OutputSelectScreen(Item* item, bool isDefaultEndpoint, uint8_t leftArrow, uint8_t rightArrow, uint8_t modeIndex);
     void OutputEditScreen(Item* item, uint8_t modeIndex);

--- a/Embedded/MaxMix/platformio.ini
+++ b/Embedded/MaxMix/platformio.ini
@@ -16,4 +16,4 @@ include_dir = src
 platform = atmelavr
 board = nanoatmega328
 framework = arduino
-upload_port = COM5
+upload_port = COM15


### PR DESCRIPTION
## Issues
 - Resolves #169 
 - Closes #

## Description
I made the splash screen into a new mode with multiple screens that you can cycle through by tapping like any other mode. Currently there are 2 states, logo and info.
I added the "info" screen which at the moment just displays the firmware version.
Created a version define that we can override at compile time in the build process to use the actual release version.

**Disclaimer**
I had to use 3 separate defines for major, minor and patch instead of a string because the arduino-cli does not support string type defines due to a bug (https://github.com/arduino/arduino-cli/issues/846#issuecomment-678842289)

## Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Requested changes are in a branch
- [ ] Compiled and tested requested changes on target hardware (PC, device)
- [ ] Updated the documentation, if necessary
- [ ] Updated the LICENSES file, if necessary
- [ ] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository
