### PR TITLE
Fw memory optimization

### DIFF
--- a/Desktop/Application/MaxMix/Services/Communication/Messages/MessageAddSession.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Messages/MessageAddSession.cs
@@ -40,12 +40,11 @@ namespace MaxMix.Services.Communication.Messages
         private void EncodeName()
         {
             EncodedName = Name.ToUpper();
-
-            if (EncodedName.Length > _nameLength)
+            if (EncodedName.Length >= _nameLength)
             {
-                EncodedName = EncodedName.Substring(0, _nameLength);
+                EncodedName = EncodedName.Substring(0, _nameLength - 1) + "\0";
             }
-            else if (EncodedName.Length < _nameLength)
+            else 
             {
                 while (EncodedName.Length < _nameLength)
                 {

--- a/Desktop/Application/MaxMix/Services/Communication/Messages/MessageAddSession.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Messages/MessageAddSession.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using ControlzEx.Standard;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -22,7 +24,7 @@ namespace MaxMix.Services.Communication.Messages
         #endregion
 
         #region Consts
-        private readonly int _nameLength = 36;
+        private readonly int _nameLength = 24;
         #endregion
         
         #region Properties
@@ -60,12 +62,12 @@ namespace MaxMix.Services.Communication.Messages
         * CHUNK        TYPE        SIZE (BYTES)
         * ---------------------------------------
         * ID           INT32       4
-        * NAME         STRING      36
+        * NAME         STRING      24
         * VOLUME       BYTE        1
         * ISMUTED      BYTE        1
         * ISDEVICE     BYTE        1
         * ---------------------------------------
-        *                          43
+        *                          31
         */
 
         public byte[] GetBytes()

--- a/Desktop/Application/MaxMix/Services/Communication/Messages/MessageSettings.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Messages/MessageSettings.cs
@@ -68,7 +68,8 @@ namespace MaxMix.Services.Communication.Messages
         * MIXCHANNELACOLOR          BYTE[]      3
         * MIXCHANNELBCOLOR          BYTE[]      3
         * ---------------------------------------------------
-        */
+        *                                       19
+        */                                       
 
         public byte[] GetBytes()
         {

--- a/Embedded/MaxMix/Commands.ino
+++ b/Embedded/MaxMix/Commands.ino
@@ -71,8 +71,8 @@ void UpdateItemCommand(uint8_t* packageBuffer, Item* itemsBuffer, uint8_t itemIn
 {
   itemsBuffer[itemIndex].id = GetIdFromPackage(packageBuffer);
   memcpy(itemsBuffer[itemIndex].name, &packageBuffer[6], ITEM_BUFFER_NAME_SIZE);
-  itemsBuffer[itemIndex].volume = (uint8_t)packageBuffer[42];
-  itemsBuffer[itemIndex].isMuted = (uint8_t)packageBuffer[43];
+  itemsBuffer[itemIndex].volume = (uint8_t)packageBuffer[30];
+  itemsBuffer[itemIndex].isMuted = (uint8_t)packageBuffer[31];
 }
 
 //---------------------------------------------------------
@@ -150,7 +150,7 @@ uint32_t GetIdFromPackage(uint8_t* packageBuffer)
 
 bool GetIsDeviceFromAddPackage(uint8_t* packageBuffer)
 {
-    return packageBuffer[44] > 0;
+    return packageBuffer[32] > 0;
 }
 
 bool GetIsDeviceFromRemovePackage(uint8_t* packageBuffer)

--- a/Embedded/MaxMix/Config.h
+++ b/Embedded/MaxMix/Config.h
@@ -82,8 +82,8 @@ static const uint8_t  PIXELS_BRIGHTNESS = 96; // Master brightness of all the pi
 static const uint16_t ROTARY_ACCELERATION_DIVISOR_MAX = 400;
 
 // --- Messages
-static const uint8_t DEVICE_MAX_COUNT = 3;
-static const uint8_t SESSION_MAX_COUNT = 5;
+static const uint8_t DEVICE_MAX_COUNT = 4;
+static const uint8_t SESSION_MAX_COUNT = 6;
 static const uint8_t ITEM_BUFFER_NAME_SIZE = 24;
 static const uint8_t RECEIVE_BUFFER_SIZE = 36; // 1 overhead + 1 revision + 1 command + (31) payload + 1 length + 1 end byte.
 static const uint8_t DECODE_BUFFER_SIZE = 31; // Largest message received.

--- a/Embedded/MaxMix/Config.h
+++ b/Embedded/MaxMix/Config.h
@@ -84,9 +84,11 @@ static const uint16_t ROTARY_ACCELERATION_DIVISOR_MAX = 400;
 // --- Messages
 static const uint8_t DEVICE_MAX_COUNT = 3;
 static const uint8_t SESSION_MAX_COUNT = 5;
-static const uint8_t ITEM_BUFFER_NAME_SIZE = 36;
-static const uint8_t RECEIVE_BUFFER_SIZE = 128;
-static const uint8_t SEND_BUFFER_SIZE = 9;
+static const uint8_t ITEM_BUFFER_NAME_SIZE = 24;
+static const uint8_t RECEIVE_BUFFER_SIZE = 36; // 1 overhead + 1 revision + 1 command + (31) payload + 1 length + 1 end byte.
+static const uint8_t DECODE_BUFFER_SIZE = 31; // Largest message received.
+static const uint8_t SEND_BUFFER_SIZE = 7; // Largest message sent (7) + 1 command.
+static const uint8_t ENCODE_BUFFER_SIZE = 10; //  1 overhead + (7) payload + 1 length + 1 end byte.
 
 // These values match exactly the ones in the C# application.
 static const uint8_t MSG_COMMAND_HANDSHAKE_REQUEST =  0;

--- a/Embedded/MaxMix/MaxMix.ino
+++ b/Embedded/MaxMix/MaxMix.ino
@@ -39,9 +39,9 @@
 uint8_t receiveIndex = 0;
 uint8_t sendIndex = 0;
 uint8_t receiveBuffer[RECEIVE_BUFFER_SIZE];
-uint8_t decodeBuffer[RECEIVE_BUFFER_SIZE];
+uint8_t decodeBuffer[DECODE_BUFFER_SIZE];
 uint8_t sendBuffer[SEND_BUFFER_SIZE];
-uint8_t encodeBuffer[SEND_BUFFER_SIZE];
+uint8_t encodeBuffer[ENCODE_BUFFER_SIZE];
 
 // State
 uint8_t mode = MODE_SPLASH;

--- a/Embedded/MaxMix/Structs.h
+++ b/Embedded/MaxMix/Structs.h
@@ -10,7 +10,7 @@ typedef struct  __attribute__((__packed__)) {
 
 typedef struct __attribute__((__packed__))
 {
-  char name[ITEM_BUFFER_NAME_SIZE]; // 36 Bytes (36 Chars)
+  char name[ITEM_BUFFER_NAME_SIZE]; // 24 Bytes ( Chars)
   uint32_t id;                      // 4 Bytes (32 bit)
   int8_t volume;                    // 1 Byte
   uint8_t isMuted;                  // 1 Byte
@@ -29,6 +29,6 @@ typedef struct __attribute__((__packed__))
   Color mixChannelBColor = {0xFF, 0x00, 0xFF};  // 3 Bytes 
 } Settings;
 
-static_assert(sizeof(Item) == 42, "'Item' struct not the expected size");
+static_assert(sizeof(Item) == 30, "'Item' struct not the expected size");
 static_assert(sizeof(Settings) == 17, "'Settings' struct not the expected size");
 static_assert(sizeof(Color) == 3, "'Settings' struct not the expected size");

--- a/Embedded/MaxMix/Structs.h
+++ b/Embedded/MaxMix/Structs.h
@@ -4,13 +4,13 @@
 
 typedef struct  __attribute__((__packed__)) {
   uint8_t r;  // 1 Byte 
-  uint8_t g;   // 1 Byte
+  uint8_t g;  // 1 Byte
   uint8_t b;  // 1 Byte
 } Color;
 
 typedef struct __attribute__((__packed__))
 {
-  char name[ITEM_BUFFER_NAME_SIZE]; // 24 Bytes ( Chars)
+  char name[ITEM_BUFFER_NAME_SIZE]; // 24 Bytes (Chars)
   uint32_t id;                      // 4 Bytes (32 bit)
   int8_t volume;                    // 1 Byte
   uint8_t isMuted;                  // 1 Byte


### PR DESCRIPTION
## Issues
 - Fixes #188 

## Description
* Reduced item name size from 36 to 24.
* Adjusted send, receive, encode and decode buffers to fit exactly the longest messages we have.

Before:
RAM:   [======    ]  63.5% (used 1300 bytes from 2048 bytes)
Flash: [========  ]  79.9% (used 24542 bytes from 30720 bytes)

After:
RAM:   [=====     ]  49.5% (used 1014 bytes from 2048 bytes)
Flash: [========  ]  79.9% (used 24542 bytes from 30720 bytes)

## Types of changes
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Requested changes are in a branch
- [X] Compiled and tested requested changes on target hardware (PC, device)
- [X] Updated the documentation, if necessary
- [x] Updated the LICENSES file, if necessary
- [x] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
