### PR TITLE
Special session name treatment for Spotify

### DIFF
--- a/Desktop/Application/MaxMix/Services/Audio/AudioSession.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioSession.cs
@@ -116,13 +116,28 @@ namespace MaxMix.Services.Audio
         private void UpdateDisplayName()
         {
             var displayName = _session2.DisplayName;
-            if (IsSystemSound) { displayName = "System Sounds"; }
-            if (string.IsNullOrEmpty(displayName)) { displayName = _session2.Process.MainWindowTitle; }
-            if (string.IsNullOrEmpty(displayName)) { displayName = _session2.Process.GetProductName(); }
-            if (string.IsNullOrEmpty(displayName)) { displayName = _session2.Process.ProcessName; }
-            if (string.IsNullOrEmpty(displayName)) { displayName = "Unnamed"; }
-            displayName = char.ToUpper(displayName[0]) + displayName.Substring(1);
+            if (IsSystemSound) {
+                displayName = "System Sounds";
+            }
+            else
+            {
+                var productName = _session2.Process.GetProductName();
+                if (productName == "Spotify")
+                {
+                    // For Spotify we simply use the product name so we are not
+                    // stuck with an old song/window title after the song changes.
+                    displayName = productName;
+                }
+                else
+                {
+                    if (string.IsNullOrEmpty(displayName)) { displayName = _session2.Process.MainWindowTitle; }
+                    if (string.IsNullOrEmpty(displayName)) { displayName = productName; }
+                    if (string.IsNullOrEmpty(displayName)) { displayName = _session2.Process.ProcessName; }
+                    if (string.IsNullOrEmpty(displayName)) { displayName = "Unnamed"; }
+                }
+            }
 
+            displayName = char.ToUpper(displayName[0]) + displayName.Substring(1);
             DisplayName = displayName;
         }
         #endregion

--- a/Desktop/Application/MaxMix/Services/Audio/AudioSession.cs
+++ b/Desktop/Application/MaxMix/Services/Audio/AudioSession.cs
@@ -121,23 +121,12 @@ namespace MaxMix.Services.Audio
             }
             else
             {
-                var productName = _session2.Process.GetProductName();
-                if (productName == "Spotify")
-                {
-                    // For Spotify we simply use the product name so we are not
-                    // stuck with an old song/window title after the song changes.
-                    displayName = productName;
-                }
-                else
-                {
-                    if (string.IsNullOrEmpty(displayName)) { displayName = _session2.Process.MainWindowTitle; }
-                    if (string.IsNullOrEmpty(displayName)) { displayName = productName; }
-                    if (string.IsNullOrEmpty(displayName)) { displayName = _session2.Process.ProcessName; }
-                    if (string.IsNullOrEmpty(displayName)) { displayName = "Unnamed"; }
-                }
+                if (string.IsNullOrEmpty(displayName)) { displayName = _session2.Process.GetProductName(); }
+                if (string.IsNullOrEmpty(displayName)) { displayName = _session2.Process.MainWindowTitle; }
+                if (string.IsNullOrEmpty(displayName)) { displayName = _session2.Process.ProcessName; }
+                if (string.IsNullOrEmpty(displayName)) { displayName = "Unnamed"; }
+                displayName = char.ToUpper(displayName[0]) + displayName.Substring(1);
             }
-
-            displayName = char.ToUpper(displayName[0]) + displayName.Substring(1);
             DisplayName = displayName;
         }
         #endregion


### PR DESCRIPTION
## Issues
 - Fixes #179 

## Description
Added a special condition for Spotify where we don't attempt to use the window title as the session name.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Requested changes are in a branch
- [x] Compiled and tested requested changes on target hardware (PC, device)
- [ ] Updated the documentation, if necessary
- [ ] Updated the LICENSES file, if necessary
- [x] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository

