### PR TITLE
Ignoring button input in splash mode

### DIFF
--- a/Embedded/MaxMix/MaxMix.ino
+++ b/Embedded/MaxMix/MaxMix.ino
@@ -646,6 +646,15 @@ bool ProcessEncoderButton()
   
   else if(encoderButton.doubleTapped())
   {
+    if(stateDisplay == STATE_DISPLAY_SLEEP)
+    {
+      return true;
+    }
+
+    if(mode == MODE_SPLASH)
+    {
+      return false;
+    }
     if(mode == MODE_OUTPUT)
     {
       ToggleMute(devicesOutput, itemIndexOutput);
@@ -668,11 +677,17 @@ bool ProcessEncoderButton()
   else if(encoderButton.held())
   {
     if(stateDisplay == STATE_DISPLAY_SLEEP)
+    {
       return true;
+    }
+
+    if(mode == MODE_SPLASH)
+    {
+      return false;
+    }
       
     CycleMode();
     Display::ResetTimers();
-
     return true;
   }
 


### PR DESCRIPTION
## Issues

## Description
Fixing hold and double-tap not being ignored while in the splash screen (not connected)

## Types of changes
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Requested changes are in a branch
- [X] Compiled and tested requested changes on target hardware (PC, device)
- [X] Updated the documentation, if necessary
- [X] Updated the LICENSES file, if necessary
- [X] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
