### PR TITLE
Start with windows

### DIFF
--- a/Desktop/Application/MaxMix/App.config
+++ b/Desktop/Application/MaxMix/App.config
@@ -19,7 +19,7 @@
             <setting name="SleepAfterSeconds" serializeAs="String">
                 <value>5</value>
             </setting>
-            <setting name="LoopAroundApplications" serializeAs="String">
+            <setting name="LoopAroundItems" serializeAs="String">
                 <value>True</value>
             </setting>
             <setting name="AccelerationPercentage" serializeAs="String">

--- a/Desktop/Application/MaxMix/App.config
+++ b/Desktop/Application/MaxMix/App.config
@@ -19,7 +19,7 @@
             <setting name="SleepAfterSeconds" serializeAs="String">
                 <value>5</value>
             </setting>
-            <setting name="ContinuousScroll" serializeAs="String">
+            <setting name="LoopAroundApplications" serializeAs="String">
                 <value>True</value>
             </setting>
             <setting name="AccelerationPercentage" serializeAs="String">

--- a/Desktop/Application/MaxMix/App.xaml.cs
+++ b/Desktop/Application/MaxMix/App.xaml.cs
@@ -84,9 +84,12 @@ namespace MaxMix
             viewModel.Stop();
 
             // Calling dispose explicitly on closing so the icon dissapears from the windows task bar.
-            var window = (MainWindow)Application.Current.MainWindow;            
+            var window = (MainWindow)Application.Current.MainWindow;
             window.taskbarIcon.Dispose();
-            _errorReporter.Dispose();
+            if (_errorReporter != null)
+            {
+                _errorReporter.Dispose();
+            }
             _singleInstanceMutex.Dispose();
 
             Application.Current.Shutdown();

--- a/Desktop/Application/MaxMix/Properties/Settings.Designer.cs
+++ b/Desktop/Application/MaxMix/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace MaxMix.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.5.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.7.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -62,12 +62,12 @@ namespace MaxMix.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
-        public bool ContinuousScroll {
+        public bool LoopAroundApplications {
             get {
-                return ((bool)(this["ContinuousScroll"]));
+                return ((bool)(this["LoopAroundApplications"]));
             }
             set {
-                this["ContinuousScroll"] = value;
+                this["LoopAroundApplications"] = value;
             }
         }
         

--- a/Desktop/Application/MaxMix/Properties/Settings.Designer.cs
+++ b/Desktop/Application/MaxMix/Properties/Settings.Designer.cs
@@ -62,12 +62,12 @@ namespace MaxMix.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
-        public bool LoopAroundApplications {
+        public bool LoopAroundItems {
             get {
-                return ((bool)(this["LoopAroundApplications"]));
+                return ((bool)(this["LoopAroundItems"]));
             }
             set {
-                this["LoopAroundApplications"] = value;
+                this["LoopAroundItems"] = value;
             }
         }
         

--- a/Desktop/Application/MaxMix/Properties/Settings.settings
+++ b/Desktop/Application/MaxMix/Properties/Settings.settings
@@ -11,7 +11,7 @@
     <Setting Name="SleepAfterSeconds" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">5</Value>
     </Setting>
-    <Setting Name="ContinuousScroll" Type="System.Boolean" Scope="User">
+    <Setting Name="LoopAroundApplications" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="AccelerationPercentage" Type="System.UInt32" Scope="User">

--- a/Desktop/Application/MaxMix/Properties/Settings.settings
+++ b/Desktop/Application/MaxMix/Properties/Settings.settings
@@ -11,7 +11,7 @@
     <Setting Name="SleepAfterSeconds" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">5</Value>
     </Setting>
-    <Setting Name="LoopAroundApplications" Type="System.Boolean" Scope="User">
+    <Setting Name="LoopAroundItems" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="AccelerationPercentage" Type="System.UInt32" Scope="User">

--- a/Desktop/Application/MaxMix/Services/Communication/Messages/MessageSettings.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Messages/MessageSettings.cs
@@ -14,7 +14,7 @@ namespace MaxMix.Services.Communication.Messages
             bool displayNewSession,
             bool sleepWhenInactive,
             int sleepAfterSeconds,
-            bool continuousScroll,
+            bool loopAroundApplications,
             uint accelerationPercentage,
             ushort doubleTapTime,
             uint volumeMinColor,
@@ -25,7 +25,7 @@ namespace MaxMix.Services.Communication.Messages
             DisplayNewSession = displayNewSession;
             SleepWhenInactive = sleepWhenInactive;
             SleepAfterSeconds = sleepAfterSeconds;
-            ContinuousScroll = continuousScroll;
+            LoopAroundApplications = loopAroundApplications;
             AccelerationPercentage = accelerationPercentage;
             DoubleTapTime = doubleTapTime;
             VolumeMinColor = volumeMinColor;
@@ -38,7 +38,7 @@ namespace MaxMix.Services.Communication.Messages
         #region Properties
         public bool DisplayNewSession { get; private set; }
         public bool SleepWhenInactive { get; private set; }
-        public bool ContinuousScroll { get; private set; }
+        public bool LoopAroundApplications { get; private set; }
         public int SleepAfterSeconds { get; private set; }
         public uint AccelerationPercentage { get; private set; }
         public ushort DoubleTapTime { get; private set; }
@@ -60,7 +60,7 @@ namespace MaxMix.Services.Communication.Messages
         * DISPLAYNEWSESSION         BYTE        1
         * SLEEPWHENINACTIVE         BYTE        1
         * SLEEPAFTERSECONDS         BYTE        1
-        * CONTINUOUSSCROLL          BYTE        1
+        * LOOPAROUNDAPPLICATIONS    BYTE        1
         * ACCELERATIONPERCENTAGE    BYTE        1
         * DOUBLETAPTIME             USHORT      2
         * VOLUMEMINCOLOR            BYTE[]      3
@@ -69,7 +69,7 @@ namespace MaxMix.Services.Communication.Messages
         * MIXCHANNELBCOLOR          BYTE[]      3
         * ---------------------------------------------------
         *                                       19
-        */                                       
+        */
 
         public byte[] GetBytes()
         {
@@ -78,7 +78,7 @@ namespace MaxMix.Services.Communication.Messages
             result.Add(Convert.ToByte(DisplayNewSession));
             result.Add(Convert.ToByte(SleepWhenInactive));
             result.Add(Convert.ToByte(SleepAfterSeconds));
-            result.Add(Convert.ToByte(ContinuousScroll));
+            result.Add(Convert.ToByte(LoopAroundApplications));
             result.Add(Convert.ToByte(AccelerationPercentage));
             result.AddRange(BitConverter.GetBytes(DoubleTapTime));
             result.AddRange(GetColorTriplet(VolumeMinColor));

--- a/Desktop/Application/MaxMix/Services/Communication/Messages/MessageSettings.cs
+++ b/Desktop/Application/MaxMix/Services/Communication/Messages/MessageSettings.cs
@@ -14,7 +14,7 @@ namespace MaxMix.Services.Communication.Messages
             bool displayNewSession,
             bool sleepWhenInactive,
             int sleepAfterSeconds,
-            bool loopAroundApplications,
+            bool loopAroundItems,
             uint accelerationPercentage,
             ushort doubleTapTime,
             uint volumeMinColor,
@@ -25,7 +25,7 @@ namespace MaxMix.Services.Communication.Messages
             DisplayNewSession = displayNewSession;
             SleepWhenInactive = sleepWhenInactive;
             SleepAfterSeconds = sleepAfterSeconds;
-            LoopAroundApplications = loopAroundApplications;
+            LoopAroundItems = loopAroundItems;
             AccelerationPercentage = accelerationPercentage;
             DoubleTapTime = doubleTapTime;
             VolumeMinColor = volumeMinColor;
@@ -38,7 +38,7 @@ namespace MaxMix.Services.Communication.Messages
         #region Properties
         public bool DisplayNewSession { get; private set; }
         public bool SleepWhenInactive { get; private set; }
-        public bool LoopAroundApplications { get; private set; }
+        public bool LoopAroundItems { get; private set; }
         public int SleepAfterSeconds { get; private set; }
         public uint AccelerationPercentage { get; private set; }
         public ushort DoubleTapTime { get; private set; }
@@ -60,7 +60,7 @@ namespace MaxMix.Services.Communication.Messages
         * DISPLAYNEWSESSION         BYTE        1
         * SLEEPWHENINACTIVE         BYTE        1
         * SLEEPAFTERSECONDS         BYTE        1
-        * LOOPAROUNDAPPLICATIONS    BYTE        1
+        * LOOPAROUNDITEMS           BYTE        1
         * ACCELERATIONPERCENTAGE    BYTE        1
         * DOUBLETAPTIME             USHORT      2
         * VOLUMEMINCOLOR            BYTE[]      3
@@ -78,7 +78,7 @@ namespace MaxMix.Services.Communication.Messages
             result.Add(Convert.ToByte(DisplayNewSession));
             result.Add(Convert.ToByte(SleepWhenInactive));
             result.Add(Convert.ToByte(SleepAfterSeconds));
-            result.Add(Convert.ToByte(LoopAroundApplications));
+            result.Add(Convert.ToByte(LoopAroundItems));
             result.Add(Convert.ToByte(AccelerationPercentage));
             result.AddRange(BitConverter.GetBytes(DoubleTapTime));
             result.AddRange(GetColorTriplet(VolumeMinColor));

--- a/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
+++ b/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
@@ -168,7 +168,7 @@ namespace MaxMix.ViewModels
             var message = new MessageSettings(_settingsViewModel.DisplayNewSession,
                                               _settingsViewModel.SleepWhenInactive,
                                               _settingsViewModel.SleepAfterSeconds,
-                                              _settingsViewModel.LoopAroundApplications,
+                                              _settingsViewModel.LoopAroundItems,
                                               _settingsViewModel.AccelerationPercentage,
                                               _settingsViewModel.DoubleTapTime,
                                               _settingsViewModel.VolumeMinColor,

--- a/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
+++ b/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
@@ -168,7 +168,7 @@ namespace MaxMix.ViewModels
             var message = new MessageSettings(_settingsViewModel.DisplayNewSession,
                                               _settingsViewModel.SleepWhenInactive,
                                               _settingsViewModel.SleepAfterSeconds,
-                                              _settingsViewModel.ContinuousScroll,
+                                              _settingsViewModel.LoopAroundApplications,
                                               _settingsViewModel.AccelerationPercentage,
                                               _settingsViewModel.DoubleTapTime,
                                               _settingsViewModel.VolumeMinColor,

--- a/Desktop/Application/MaxMix/ViewModels/SettingsViewModel.cs
+++ b/Desktop/Application/MaxMix/ViewModels/SettingsViewModel.cs
@@ -42,13 +42,12 @@ namespace MaxMix.ViewModels
 
         #region Properties
         /// <summary>
-        /// When a new session is created, notify the device to make it
-        /// the current displayed item.
+        /// Should this app be run at Windows startup.
         /// </summary>
-        public bool RunAutomaticallyStartup
+        public bool RunAtStartup
         {
-            get => IsRunAutomaticallyAtStartup();
-            set => SetRunAutomaticallyAtStartup(value);
+            get => IsRunAtStartup();
+            set => SetRunAtStartup(value);
         }
 
         /// <summary>
@@ -96,12 +95,12 @@ namespace MaxMix.ViewModels
         /// <summary>
         /// Enable to loop around the applications list.
         /// </summary>
-        public bool LoopAroundApplications
+        public bool LoopAroundItems
         {
-            get => _settings.LoopAroundApplications;
+            get => _settings.LoopAroundItems;
             set
             {
-                _settings.LoopAroundApplications = value;
+                _settings.LoopAroundItems = value;
                 RaisePropertyChanged();
             }
         }
@@ -203,7 +202,7 @@ namespace MaxMix.ViewModels
         #endregion
 
         #region Private Methods
-        private bool IsRunAutomaticallyAtStartup()
+        private bool IsRunAtStartup()
         {
             try
             {
@@ -216,7 +215,7 @@ namespace MaxMix.ViewModels
             }
             return false;
         }
-        private void SetRunAutomaticallyAtStartup(bool enabled)
+        private void SetRunAtStartup(bool enabled)
         {
             try
             {

--- a/Desktop/Application/MaxMix/ViewModels/SettingsViewModel.cs
+++ b/Desktop/Application/MaxMix/ViewModels/SettingsViewModel.cs
@@ -14,6 +14,7 @@ using System.Windows;
 using MaxMix.Framework.Mvvm;
 using MaxMix.Services.Communication;
 using System.Runtime.CompilerServices;
+using System.Reflection;
 
 namespace MaxMix.ViewModels
 {
@@ -40,6 +41,16 @@ namespace MaxMix.ViewModels
         #endregion
 
         #region Properties
+        /// <summary>
+        /// When a new session is created, notify the device to make it
+        /// the current displayed item.
+        /// </summary>
+        public bool RunAutomaticallyStartup
+        {
+            get => IsRunAutomaticallyAtStartup();
+            set => SetRunAutomaticallyAtStartup(value);
+        }
+
         /// <summary>
         /// When a new session is created, notify the device to make it
         /// the current displayed item.
@@ -81,13 +92,16 @@ namespace MaxMix.ViewModels
             }
         }
 
-        // TODO: Delete, updates are checked automatically at application launch.
-        public bool ContinuousScroll
+
+        /// <summary>
+        /// Enable to loop around the applications list.
+        /// </summary>
+        public bool LoopAroundApplications
         {
-            get => _settings.ContinuousScroll;
+            get => _settings.LoopAroundApplications;
             set
             {
-                _settings.ContinuousScroll = value;
+                _settings.LoopAroundApplications = value;
                 RaisePropertyChanged();
             }
         }
@@ -189,6 +203,39 @@ namespace MaxMix.ViewModels
         #endregion
 
         #region Private Methods
+        private bool IsRunAutomaticallyAtStartup()
+        {
+            try
+            {
+                Microsoft.Win32.RegistryKey key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", true);
+                Assembly curAssembly = Assembly.GetExecutingAssembly();
+                return ((string)(key.GetValue(curAssembly.GetName().Name)) == curAssembly.Location);
+            }
+            catch
+            {
+            }
+            return false;
+        }
+        private void SetRunAutomaticallyAtStartup(bool enabled)
+        {
+            try
+            {
+                Microsoft.Win32.RegistryKey key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", true);
+                Assembly curAssembly = Assembly.GetExecutingAssembly();
+
+                if (enabled)
+                {
+                    key.SetValue(curAssembly.GetName().Name, curAssembly.Location);
+                }
+                else
+                {
+                    key.DeleteValue(curAssembly.GetName().Name);
+                }
+            }
+            catch
+            {
+            }
+        }
         #endregion
 
         #region EventHandlers

--- a/Desktop/Application/MaxMix/Views/SettingsView.xaml
+++ b/Desktop/Application/MaxMix/Views/SettingsView.xaml
@@ -59,7 +59,7 @@
 
         <!-- AccelerationPercentage -->
         <Label Grid.Column="0" Grid.Row="5"
-               Content="Encoder acceleration (percentage)" />
+               Content="Encoder acceleration (%)" />
         <xctk:IntegerUpDown Grid.Column="1" Grid.Row="5" MaxWidth="100"
                             Foreground="{StaticResource Brush_White}"
                             Minimum="1" Maximum="100"
@@ -67,7 +67,7 @@
 
         <!-- Double Tap Time -->
         <Label Grid.Column="0" Grid.Row="6"
-               Content="Double Tap Time (ms)" />
+               Content="Double tap time (ms)" />
         <xctk:IntegerUpDown Grid.Column="1" Grid.Row="6" MaxWidth="100"
                             Foreground="{StaticResource Brush_White}"
                             Minimum="1" Maximum="2000"

--- a/Desktop/Application/MaxMix/Views/SettingsView.xaml
+++ b/Desktop/Application/MaxMix/Views/SettingsView.xaml
@@ -6,82 +6,84 @@
              xmlns:local="clr-namespace:MaxMix.Views"
              xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
              mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="300">
+             d:DesignHeight="350" d:DesignWidth="300">
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="2*" />
+            <ColumnDefinition Width="1.4*" />
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <!-- Starts -->
-        <Label Grid.Column="0" Grid.Row="0"
+        <Label Grid.Column="0" Grid.Row="0" Margin="0,3,0,6" 
                Content="Run automatically at startup" />
         <CheckBox Grid.Column="1" Grid.Row="0"
-                  IsChecked="{Binding RunAutomaticallyStartup}" />
+                  IsChecked="{Binding RunAtStartup}" />
 
         <!-- DisplayNewSession -->
-        <Label Grid.Column="0" Grid.Row="1"
+        <Label Grid.Column="0" Grid.Row="1" Margin="0,3,0,6"
                Content="Switch to new application" />
         <CheckBox Grid.Column="1" Grid.Row="1"
                   IsChecked="{Binding DisplayNewSession}" />
 
-        <!-- SleepWhenInactive -->
-        <Label Grid.Column="0" Grid.Row="2"
-               Content="Sleep when inactive" />
+        <!-- LoopAroundItems -->
+        <Label Grid.Column="0" Grid.Row="2" Margin="0,3,0,6"
+               Content="Loop around items" />
         <CheckBox Grid.Column="1" Grid.Row="2"
+                  IsChecked="{Binding LoopAroundItems}" />
+
+        <!-- SleepWhenInactive -->
+        <Label Grid.Column="0" Grid.Row="3" Margin="0,3,0,6"
+               Content="Sleep when inactive" />
+        <CheckBox Grid.Column="1" Grid.Row="3"
                   IsChecked="{Binding SleepWhenInactive}" />
 
         <!-- SleepAfterSeconds -->
-        <Label Grid.Column="0" Grid.Row="3"
+        <Label Grid.Column="0" Grid.Row="4" Margin="0,3,0,6"
                Content="Sleep after (seconds)" />
-        <xctk:IntegerUpDown Grid.Column="1" Grid.Row="3" MaxWidth="100" HorizontalAlignment="Left"
+        <xctk:IntegerUpDown Grid.Column="1" Grid.Row="4" MinWidth="50" HorizontalAlignment="Left"
                             Foreground="{StaticResource Brush_White}"
                             Minimum="0" Maximum="60"
                             Value="{Binding SleepAfterSeconds}" />
 
-        <!-- LoopAroundApplications -->
-        <Label Grid.Column="0" Grid.Row="4"
-               Content="Loop around applications" />
-        <CheckBox Grid.Column="1" Grid.Row="4"
-                  IsChecked="{Binding LoopAroundApplications}" />
-
         <!-- AccelerationPercentage -->
-        <Label Grid.Column="0" Grid.Row="5"
+        <Label Grid.Column="0" Grid.Row="5" Margin="0,3,0,6"
                Content="Encoder acceleration (%)" />
-        <xctk:IntegerUpDown Grid.Column="1" Grid.Row="5" MaxWidth="100"
+        <xctk:IntegerUpDown Grid.Column="1" Grid.Row="5" MinWidth="50" HorizontalAlignment="Left"
                             Foreground="{StaticResource Brush_White}"
                             Minimum="1" Maximum="100"
                             Value="{Binding AccelerationPercentage}" />
 
         <!-- Double Tap Time -->
-        <Label Grid.Column="0" Grid.Row="6"
+        <Label Grid.Column="0" Grid.Row="6" Margin="0,3,0,6"
                Content="Double tap time (ms)" />
-        <xctk:IntegerUpDown Grid.Column="1" Grid.Row="6" MaxWidth="100"
+        <xctk:IntegerUpDown Grid.Column="1" Grid.Row="6" MinWidth="50" HorizontalAlignment="Left"
                             Foreground="{StaticResource Brush_White}"
                             Minimum="1" Maximum="2000"
                             Value="{Binding DoubleTapTime}" />
 
         <!-- Volume colors -->
-        <Label Grid.Column="0" Grid.Row="7" Content="Volume colors" />
+        <Label Grid.Column="0" Grid.Row="7" Margin="0,3,0,6"
+               Content="Volume colors" />
         <StackPanel Grid.Column="1" Grid.Row="7" Orientation="Horizontal">
             <xctk:ColorPicker MaxWidth="50" SelectedColor="{Binding VolumeMinColor, Converter={StaticResource Cnv_ColorToUint32}}" />
             <xctk:ColorPicker MaxWidth="50" SelectedColor="{Binding VolumeMaxColor,  Converter={StaticResource Cnv_ColorToUint32}}" />
         </StackPanel>
 
         <!-- Mix Channel colors -->
-        <Label Grid.Column="0" Grid.Row="8" Content="Mix channel colors" />
+        <Label Grid.Column="0" Grid.Row="8"  Margin="0,3,0,6"
+               Content="Mix channel colors" />
         <StackPanel Grid.Column="1" Grid.Row="8" Orientation="Horizontal">
             <xctk:ColorPicker MaxWidth="50" SelectedColor="{Binding MixChannelAColor, Converter={StaticResource Cnv_ColorToUint32}}" />
             <xctk:ColorPicker MaxWidth="50" SelectedColor="{Binding MixChannelBColor,  Converter={StaticResource Cnv_ColorToUint32}}" />

--- a/Desktop/Application/MaxMix/Views/SettingsView.xaml
+++ b/Desktop/Application/MaxMix/Views/SettingsView.xaml
@@ -22,32 +22,40 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <!-- DisplayNewSession -->
+        <!-- Starts -->
         <Label Grid.Column="0" Grid.Row="0"
-               Content="Switch to new application" />
+               Content="Run automatically at startup" />
         <CheckBox Grid.Column="1" Grid.Row="0"
+                  IsChecked="{Binding RunAutomaticallyStartup}" />
+
+        <!-- DisplayNewSession -->
+        <Label Grid.Column="0" Grid.Row="1"
+               Content="Switch to new application" />
+        <CheckBox Grid.Column="1" Grid.Row="1"
                   IsChecked="{Binding DisplayNewSession}" />
 
         <!-- SleepWhenInactive -->
-        <Label Grid.Column="0" Grid.Row="1"
+        <Label Grid.Column="0" Grid.Row="2"
                Content="Sleep when inactive" />
-        <CheckBox Grid.Column="1" Grid.Row="1"
+        <CheckBox Grid.Column="1" Grid.Row="2"
                   IsChecked="{Binding SleepWhenInactive}" />
 
         <!-- SleepAfterSeconds -->
-        <Label Grid.Column="0" Grid.Row="2"
+        <Label Grid.Column="0" Grid.Row="3"
                Content="Sleep after (seconds)" />
-        <xctk:IntegerUpDown Grid.Column="1" Grid.Row="2" MaxWidth="100" HorizontalAlignment="Left"
+        <xctk:IntegerUpDown Grid.Column="1" Grid.Row="3" MaxWidth="100" HorizontalAlignment="Left"
                             Foreground="{StaticResource Brush_White}"
                             Minimum="0" Maximum="60"
                             Value="{Binding SleepAfterSeconds}" />
 
-        <Label Grid.Column="0" Grid.Row="3"
+        <!-- LoopAroundApplications -->
+        <Label Grid.Column="0" Grid.Row="4"
                Content="Loop around applications" />
-        <CheckBox Grid.Column="1" Grid.Row="3"
-                  IsChecked="{Binding ContinuousScroll}" />
+        <CheckBox Grid.Column="1" Grid.Row="4"
+                  IsChecked="{Binding LoopAroundApplications}" />
 
         <!-- AccelerationPercentage -->
         <Label Grid.Column="0" Grid.Row="5"


### PR DESCRIPTION
## Issues
 - Fixes #194 

## Description
Added a new entry "Run automatically at startup" to the settings GUI which allow to create the appropriate windows' registry entry to start the desktop app after login in windows.

To avoid any synchronization issues (ex : having the checkbox "On" but without the equivalent registry entry or vice-versa) this settings is not saved in the user.config file like a regular setting.    Also this setting is not sent to the device, so it does not go through the usual RaisePropertyChanged().

While I was in the settings I fixed a couple of typo (camel cases) and renamed ContinuousScroll to the front-end name : LoopAroundApplications.

Also added a if() so the app doesn't crash in Debug when exiting via the tray icon because sentry is not initialized.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Requested changes are in a branch
- [x] Compiled and tested requested changes on target hardware (PC, device)
- [ ] Updated the documentation, if necessary
- [ ] Updated the LICENSES file, if necessary
- [x] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository

