### PR TITLE
Added a simple items blacklist mechanism + fixed saving settings  + typo

### DIFF
--- a/Desktop/Application/MaxMix/App.config
+++ b/Desktop/Application/MaxMix/App.config
@@ -37,8 +37,11 @@
             <setting name="MixChannelAColor" serializeAs="String">
                 <value>4278190335</value>
             </setting>
-            <setting name="MixChanneBColor" serializeAs="String">
+            <setting name="MixChannelBColor" serializeAs="String">
                 <value>4294902015</value>
+            </setting>
+            <setting name="ItemsBlackList" serializeAs="String">
+              <value></value>
             </setting>
         </MaxMix.Properties.Settings>
     </userSettings>

--- a/Desktop/Application/MaxMix/Framework/Mvvm/ObservableObject.cs
+++ b/Desktop/Application/MaxMix/Framework/Mvvm/ObservableObject.cs
@@ -26,6 +26,8 @@ namespace MaxMix.Framework.Mvvm
         {
             if (PropertyChanged != null && name != null)
                 PropertyChanged(this, new PropertyChangedEventArgs(name));
+
+            Properties.Settings.Default.Save();
         }
         #endregion
     }

--- a/Desktop/Application/MaxMix/MainWindow.xaml
+++ b/Desktop/Application/MaxMix/MainWindow.xaml
@@ -7,7 +7,7 @@
                  xmlns:ap="clr-namespace:MaxMix.Framework.AttachedProperties"
                  xmlns:v="clr-namespace:MaxMix.Views"
                  MinWidth="300" MinHeight="300" 
-                 Width="300" Height="400"
+                 Width="300" Height="500"
                  ShowInTaskbar="False"
                  ShowMaxRestoreButton="False"
                  ShowMinButton="False"

--- a/Desktop/Application/MaxMix/MainWindow.xaml
+++ b/Desktop/Application/MaxMix/MainWindow.xaml
@@ -7,7 +7,7 @@
                  xmlns:ap="clr-namespace:MaxMix.Framework.AttachedProperties"
                  xmlns:v="clr-namespace:MaxMix.Views"
                  MinWidth="300" MinHeight="300" 
-                 Width="300" Height="500"
+                 Width="300" Height="510"
                  ShowInTaskbar="False"
                  ShowMaxRestoreButton="False"
                  ShowMinButton="False"

--- a/Desktop/Application/MaxMix/Properties/Settings.Designer.cs
+++ b/Desktop/Application/MaxMix/Properties/Settings.Designer.cs
@@ -134,12 +134,24 @@ namespace MaxMix.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("4278190335")]
-        public uint MixChanneBColor {
+        public uint MixChannelBColor {
             get {
-                return ((uint)(this["MixChanneBColor"]));
+                return ((uint)(this["MixChannelBColor"]));
             }
             set {
-                this["MixChanneBColor"] = value;
+                this["MixChannelBColor"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string ItemsBlackList {
+            get {
+                return ((string)(this["ItemsBlackList"]));
+            }
+            set {
+                this["ItemsBlackList"] = value;
             }
         }
     }

--- a/Desktop/Application/MaxMix/Properties/Settings.settings
+++ b/Desktop/Application/MaxMix/Properties/Settings.settings
@@ -29,8 +29,11 @@
     <Setting Name="MixChannelAColor" Type="System.UInt32" Scope="User">
       <Value Profile="(Default)">4294901760</Value>
     </Setting>
-    <Setting Name="MixChanneBColor" Type="System.UInt32" Scope="User">
+    <Setting Name="MixChannelBColor" Type="System.UInt32" Scope="User">
       <Value Profile="(Default)">4278190335</Value>
+    </Setting>
+    <Setting Name="ItemsBlackList" Type="System.String" Scope="User">
+      <Value Profile="(Default)"></Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
+++ b/Desktop/Application/MaxMix/ViewModels/MainViewModel.cs
@@ -183,6 +183,13 @@ namespace MaxMix.ViewModels
         {
             ExitRequested?.Invoke(this, EventArgs.Empty);
         }
+
+        private bool IsItemBlacklisted(string displayName)
+        {
+            string[] blackList = _settingsViewModel.ItemsBlackList.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+            return (blackList.Contains(displayName, StringComparer.OrdinalIgnoreCase));
+        }
+
         #endregion
 
         #region EventHandlers
@@ -194,6 +201,10 @@ namespace MaxMix.ViewModels
 
         private void OnDeviceCreated(object sender, int id, string displayName, int volume, bool isMuted, DeviceFlow deviceFlow)
         {
+            if (IsItemBlacklisted(displayName))
+            {
+                return;
+            }
             var message = new MessageAddItem(id, displayName, volume, isMuted, true, (int)deviceFlow);
             _communicationService.Send(message);
         }
@@ -212,6 +223,10 @@ namespace MaxMix.ViewModels
 
         private void OnAudioSessionCreated(object sender, int id, string displayName, int volume, bool isMuted)
         {
+            if (IsItemBlacklisted(displayName))
+            {
+                return;
+            }
             var message = new MessageAddItem(id, displayName, volume, isMuted, false);
             _communicationService.Send(message);
         }

--- a/Desktop/Application/MaxMix/ViewModels/SettingsViewModel.cs
+++ b/Desktop/Application/MaxMix/ViewModels/SettingsViewModel.cs
@@ -132,7 +132,6 @@ namespace MaxMix.ViewModels
             }
         }
 
-
         /// <summary>
         /// Value used to set the light color for minimum volume
         /// </summary>
@@ -179,10 +178,23 @@ namespace MaxMix.ViewModels
         /// </summary>
         public uint MixChannelBColor
         {
-            get => _settings.MixChanneBColor;
+            get => _settings.MixChannelBColor;
             set
             {
-                _settings.MixChanneBColor = value;
+                _settings.MixChannelBColor = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Value used to detect a double click from the encoder switch.
+        /// </summary>
+        public string ItemsBlackList
+        {
+            get => _settings.ItemsBlackList;
+            set
+            {
+                _settings.ItemsBlackList = value;
                 RaisePropertyChanged();
             }
         }

--- a/Desktop/Application/MaxMix/Views/SettingsView.xaml
+++ b/Desktop/Application/MaxMix/Views/SettingsView.xaml
@@ -7,6 +7,7 @@
              xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
              mc:Ignorable="d" 
              d:DesignHeight="350" d:DesignWidth="300">
+
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="1.4*" />
@@ -23,71 +24,85 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <!-- Starts -->
         <Label Grid.Column="0" Grid.Row="0" Margin="0,3,0,6" 
-               Content="Run automatically at startup" />
+            Content="Run automatically at startup" />
         <CheckBox Grid.Column="1" Grid.Row="0"
-                  IsChecked="{Binding RunAtStartup}" />
+            IsChecked="{Binding RunAtStartup}" />
 
         <!-- DisplayNewSession -->
         <Label Grid.Column="0" Grid.Row="1" Margin="0,3,0,6"
-               Content="Switch to new application" />
+            Content="Switch to new application" />
         <CheckBox Grid.Column="1" Grid.Row="1"
-                  IsChecked="{Binding DisplayNewSession}" />
+            IsChecked="{Binding DisplayNewSession}" />
 
         <!-- LoopAroundItems -->
         <Label Grid.Column="0" Grid.Row="2" Margin="0,3,0,6"
-               Content="Loop around items" />
+            Content="Loop around items" />
         <CheckBox Grid.Column="1" Grid.Row="2"
-                  IsChecked="{Binding LoopAroundItems}" />
+            IsChecked="{Binding LoopAroundItems}" />
 
         <!-- SleepWhenInactive -->
         <Label Grid.Column="0" Grid.Row="3" Margin="0,3,0,6"
-               Content="Sleep when inactive" />
+            Content="Sleep when inactive" />
         <CheckBox Grid.Column="1" Grid.Row="3"
-                  IsChecked="{Binding SleepWhenInactive}" />
+            IsChecked="{Binding SleepWhenInactive}" />
 
         <!-- SleepAfterSeconds -->
         <Label Grid.Column="0" Grid.Row="4" Margin="0,3,0,6"
-               Content="Sleep after (seconds)" />
+            Content="Sleep after (seconds)" />
         <xctk:IntegerUpDown Grid.Column="1" Grid.Row="4" MinWidth="50" HorizontalAlignment="Left"
-                            Foreground="{StaticResource Brush_White}"
-                            Minimum="0" Maximum="60"
-                            Value="{Binding SleepAfterSeconds}" />
+            Foreground="{StaticResource Brush_White}"
+            Minimum="0" Maximum="60"
+            Value="{Binding SleepAfterSeconds}" />
 
         <!-- AccelerationPercentage -->
         <Label Grid.Column="0" Grid.Row="5" Margin="0,3,0,6"
-               Content="Encoder acceleration (%)" />
+            Content="Encoder acceleration (%)" />
         <xctk:IntegerUpDown Grid.Column="1" Grid.Row="5" MinWidth="50" HorizontalAlignment="Left"
-                            Foreground="{StaticResource Brush_White}"
-                            Minimum="1" Maximum="100"
-                            Value="{Binding AccelerationPercentage}" />
+            Foreground="{StaticResource Brush_White}"
+            Minimum="1" Maximum="100"
+            Value="{Binding AccelerationPercentage}" />
 
         <!-- Double Tap Time -->
         <Label Grid.Column="0" Grid.Row="6" Margin="0,3,0,6"
-               Content="Double tap time (ms)" />
+            Content="Double tap time (ms)" />
         <xctk:IntegerUpDown Grid.Column="1" Grid.Row="6" MinWidth="50" HorizontalAlignment="Left"
-                            Foreground="{StaticResource Brush_White}"
-                            Minimum="1" Maximum="2000"
-                            Value="{Binding DoubleTapTime}" />
+            Foreground="{StaticResource Brush_White}"
+            Minimum="1" Maximum="2000"
+            Value="{Binding DoubleTapTime}" />
 
         <!-- Volume colors -->
         <Label Grid.Column="0" Grid.Row="7" Margin="0,3,0,6"
-               Content="Volume colors" />
+            Content="Volume colors" />
         <StackPanel Grid.Column="1" Grid.Row="7" Orientation="Horizontal">
             <xctk:ColorPicker MaxWidth="50" SelectedColor="{Binding VolumeMinColor, Converter={StaticResource Cnv_ColorToUint32}}" />
-            <xctk:ColorPicker MaxWidth="50" SelectedColor="{Binding VolumeMaxColor,  Converter={StaticResource Cnv_ColorToUint32}}" />
+            <xctk:ColorPicker MaxWidth="50" SelectedColor="{Binding VolumeMaxColor, Converter={StaticResource Cnv_ColorToUint32}}" />
         </StackPanel>
 
         <!-- Mix Channel colors -->
-        <Label Grid.Column="0" Grid.Row="8"  Margin="0,3,0,6"
-               Content="Mix channel colors" />
+        <Label Grid.Column="0" Grid.Row="8" Margin="0,3,0,6"
+            Content="Mix channel colors" />
         <StackPanel Grid.Column="1" Grid.Row="8" Orientation="Horizontal">
             <xctk:ColorPicker MaxWidth="50" SelectedColor="{Binding MixChannelAColor, Converter={StaticResource Cnv_ColorToUint32}}" />
-            <xctk:ColorPicker MaxWidth="50" SelectedColor="{Binding MixChannelBColor,  Converter={StaticResource Cnv_ColorToUint32}}" />
+            <xctk:ColorPicker MaxWidth="50" SelectedColor="{Binding MixChannelBColor, Converter={StaticResource Cnv_ColorToUint32}}" />
         </StackPanel>
+
+        <!-- Items Blacklist -->
+        <Label Grid.Column="0" Grid.Row="9" Margin="0,3,0,6"
+            Content="Items blacklist" />
+        <TextBox Grid.Column="0" Grid.Row="10" Grid.ColumnSpan="2" Grid.RowSpan="2"
+                TextWrapping="Wrap"
+                AcceptsReturn="True"
+                VerticalScrollBarVisibility="Visible"
+                Margin="0,0,0,-120"
+                Text="{Binding ItemsBlackList}" />
+
     </Grid>
+
 </UserControl>
 


### PR DESCRIPTION
## Issues
- Fixes #186
- Fixes #209


## Description
People have been complaining about hitting the max items limitations (Input/Output/Apps) and not seeing the items they would like on their device.
I added a new blacklist textbox at the bottom of the settings. On each line you can enter the name of the item you want to see blacklisted. You need to disconnect / reconnect the device so it forgets all previous item and start fresh.
While I was in there I added a save() for the settings via RaisePropertyChanged() because without it is was too painful to test
Also fixed a minor typo in the colors.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Requested changes are in a branch
- [x] Compiled and tested requested changes on target hardware (PC, device)
- [ ] Updated the documentation, if necessary
- [ ] Updated the LICENSES file, if necessary
- [x] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository

