### PR TITLE
Updated LightingCircularFunk to use pixel count

### DIFF
--- a/Embedded/MaxMix/Lighting.ino
+++ b/Embedded/MaxMix/Lighting.ino
@@ -52,19 +52,12 @@ void LightingCircularFunk()
   uint32_t t = millis();
   uint16_t hue = t * 20;
   uint32_t rgbColor = pixels.ColorHSV(hue);
-  uint16_t period = 500;
-
-  uint8_t startOffset = 0;
-  if ((t % period) > (period / 2))
-  {
-    startOffset = 1;
-  }
 
   pixels.clear();
-  pixels.setPixelColor(startOffset, rgbColor);
-  pixels.setPixelColor(startOffset+2, rgbColor);
-  pixels.setPixelColor(startOffset+4, rgbColor);
-  pixels.setPixelColor(startOffset+6, rgbColor);
+  for (uint8_t i = (t % 500) / 250; i < PIXELS_COUNT; i += 2)
+  {
+    pixels.setPixelColor(i, rgbColor);
+  }
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
## Issues
 - Fixes #
 - Resolves #
 - Closes #

## Description
Updates LightingCircularFunk to use pixel count instead of fixed pixel size. (Now works in 12 bit led rings)

## Types of changes
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Requested changes are in a branch
- [x] Compiled and tested requested changes on target hardware (PC, device)
- [ ] Updated the documentation, if necessary
- [ ] Updated the LICENSES file, if necessary
- [x] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
