### PR TITLE
Query available devices from Win32_PnPEntity in FirmwareInstaller

### DIFF
--- a/Desktop/FirmwareInstaller/FirmwareInstaller/FirmwareInstaller.csproj
+++ b/Desktop/FirmwareInstaller/FirmwareInstaller/FirmwareInstaller.csproj
@@ -61,6 +61,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Desktop/FirmwareInstaller/FirmwareInstaller/MainWindow.xaml
+++ b/Desktop/FirmwareInstaller/FirmwareInstaller/MainWindow.xaml
@@ -7,7 +7,7 @@
                  xmlns:att="clr-namespace:FirmwareInstaller.Framework.Attached"
                  xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
                  mc:Ignorable="d"
-                 Height="400" Width="400"
+                 Height="400" Width="500"
                  Background="{StaticResource WindowBackgroundBrush}"
                  Icon="/Resources/fwinstaller.ico">
 
@@ -18,13 +18,13 @@
             </MenuItem>
 
         </Menu>
-        
+
         <Grid Margin="10" >
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
-        
+
             <Grid Grid.Row="0" IsEnabled="{Binding IsBusy, Converter={StaticResource Cnv_BoolNegate}}">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
@@ -34,43 +34,42 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
-        
+
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width=".5*" />
                 </Grid.ColumnDefinitions>
 
-                 <!-- Versions -->
+                <!-- Versions -->
                 <Label Grid.Column="0" Grid.Row="0" Content="Version" Margin="0,0,0,0"/>
-                <ComboBox Grid.Column="1" Grid.Row="0" Margin="0,0,15,0" HorizontalAlignment="Right" MinWidth="150"
+                <ComboBox Grid.Column="1" Grid.Row="0" Margin="36,0,5,0" MinWidth="150"
                           ItemsSource="{Binding Versions}" SelectedValue="{Binding SelectedVersion}"
                           IsEnabled="{Binding ElementName=CtrlUseCustomFw, Path=IsChecked, Converter={StaticResource Cnv_BoolNegate}}"/>
 
                 <!-- COM -->
                 <Label Grid.Column="0" Grid.Row="2" Content="Port" Margin="0,5,0,0"/>
-                <ComboBox Grid.Column="1" Grid.Row="2" Margin="0,5,15,0" HorizontalAlignment="Right" MinWidth="150"
-                          ItemsSource="{Binding Ports}" SelectedValue="{Binding SelectedPort}"/>
+                <ComboBox Grid.Column="1" Grid.Row="2" Margin="36,5,5,0" MinWidth="150"
+                          ItemsSource="{Binding Ports}" DisplayMemberPath="Name" SelectedValue="{Binding SelectedPort}"/>
 
                 <!-- Custom FW -->
                 <Label Grid.Column="0" Grid.Row="3" Content="Use custom firmware" Margin="0,5,0,0"/>
-                <DockPanel  Grid.Column="1" Grid.Row="3" Margin="0,5,15,0">
-                    <CheckBox x:Name="CtrlUseCustomFw" DockPanel.Dock="Right" IsChecked="{Binding UseCustomFw}"/>
+                <DockPanel  Grid.Column="1" Grid.Row="3" Margin="0,5,0,0">
+                    <CheckBox x:Name="CtrlUseCustomFw" DockPanel.Dock="Right" IsChecked="{Binding UseCustomFw}" Margin="0,0,0,0"/>
                     <Label Content="{Binding CustomFwFilePath}" />
                 </DockPanel>
 
                 <!-- Bootloader -->
                 <Label Grid.Column="0" Grid.Row="4" Content="Use old bootloader" Margin="0,5,0,0"/>
-                <CheckBox Grid.Column="1" Grid.Row="4" Margin="0,5,15,0" HorizontalAlignment="Right"
-                          IsChecked="{Binding UseOldBootloader}"/>
+                <CheckBox Grid.Column="1" Grid.Row="4" Margin="0,0,0,0" HorizontalAlignment="Right" IsChecked="{Binding UseOldBootloader}"/>
 
                 <!-- Install -->
-                <Button Grid.Column="1" Grid.Row="5" Content="Install" Margin="0,5,15,0" MinWidth="150" HorizontalAlignment="Right"
-                        Command="{Binding InstallCommand}"/>
+                <Button Grid.Row="5" Content="Install" Margin="5,5,5,0" MinWidth="150"
+                        Command="{Binding InstallCommand}" Grid.ColumnSpan="2"/>
             </Grid>
-        
+
             <!-- Log -->
-            <ScrollViewer Grid.Row="1"  x:Name="Ctrl_LogScroll" Margin="0,25,0,0" >
-                <TextBox x:Name="Ctrl_Log" IsReadOnly="True" Text="{Binding Log, Mode=OneWay}"/>
+            <ScrollViewer Grid.Row="1"  x:Name="Ctrl_LogScroll" Margin="5,25,5,0" >
+                <TextBox x:Name="Ctrl_Log" IsReadOnly="True" Text="{Binding Log, Mode=OneWay}" Margin="0,0,0,0"/>
             </ScrollViewer>
         </Grid>
     </DockPanel>

--- a/Desktop/FirmwareInstaller/FirmwareInstaller/Services/DiscoveryService.cs
+++ b/Desktop/FirmwareInstaller/FirmwareInstaller/Services/DiscoveryService.cs
@@ -1,30 +1,82 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO.Ports;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Management;
+using System.Text.RegularExpressions;
 
 namespace FirmwareInstaller.Services
 {
+    /// <summary>
+    /// Represents a serial device.
+    /// </summary>
+    internal class COMDevice: IComparable<COMDevice>
+    {
+        public string Port { get; set; }
+        public string Name { get; set; }
+
+        #region Constructor
+        public COMDevice() { }
+        #endregion
+
+        #region Overrides
+
+        public int CompareTo(COMDevice other)
+        {
+            int currentNumber = Int32.Parse(Port.Substring(Port.Length - 1));
+            int otherNumber = Int32.Parse(other.Port.Substring(other.Port.Length - 1));
+
+            return currentNumber.CompareTo(otherNumber);
+        }
+        #endregion
+    }
+
     /// <summary>
     /// Provides functionality to find available COM ports.
     /// </summary>
     internal class DiscoveryService : BaseService
     {
+        #region Fields
+        private const string _usbDeviceQueryString = @"SELECT name FROM Win32_PnPEntity";
+        private readonly Regex _comPortRegex = new Regex(@"COM\d", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        #endregion
+
         #region Constructor
-        public DiscoveryService() {}
+        public DiscoveryService() { }
         #endregion
 
         #region Public Methods
         /// <summary>
-        /// Retrieves a list of availbale COM ports.
+        /// Retrieves a list of available devices on COM ports.
         /// </summary>
-        /// <returns>List of available COM ports.</returns>
-        public IEnumerable<string> Discover()
+        /// <returns>List of available devices on COM ports.</returns>
+        public IEnumerable<COMDevice> Discover()
         {
-            var result = SerialPort.GetPortNames();
-            return result.ToList();
+            ManagementObjectCollection usbDevices = queryUSBDevices();
+            List<COMDevice> serialDevices = filterCOMDevice(usbDevices);
+            serialDevices.Sort();
+            return serialDevices;
+        }
+        #endregion
+
+        #region Private Methods
+        private ManagementObjectCollection queryUSBDevices()
+        {
+            var moSearch = new ManagementObjectSearcher(_usbDeviceQueryString);
+            return moSearch.Get();
+        }
+
+        private List<COMDevice> filterCOMDevice(ManagementObjectCollection usbDevices)
+        {
+            var serialDevices = new List<COMDevice>();
+
+            foreach (ManagementObject device in usbDevices)
+            {
+                object deviceName = device.Properties["Name"].Value;
+                if (deviceName != null && _comPortRegex.IsMatch(deviceName.ToString()))
+                {
+                    serialDevices.Add(new COMDevice { Port = _comPortRegex.Match(deviceName.ToString()).Value, Name = deviceName.ToString()});
+                }
+            }
+            return serialDevices;
         }
         #endregion
     }

--- a/Desktop/FirmwareInstaller/FirmwareInstaller/ViewModels/MainViewModel.cs
+++ b/Desktop/FirmwareInstaller/FirmwareInstaller/ViewModels/MainViewModel.cs
@@ -59,7 +59,7 @@ namespace FirmwareInstaller.ViewModels
         private DelegateCommand _installCommand;
         private DelegateCommand<string> _loadFirmwareCommand;
 
-        private string _selectedPort;
+        private COMDevice _selectedPort;
         private string _selectedVersion;
         private string _customFwFilePath;
         private IList<string> _logList;
@@ -88,7 +88,7 @@ namespace FirmwareInstaller.ViewModels
         /// <summary>
         /// Selected COM port.
         /// </summary>
-        public string SelectedPort
+        public COMDevice SelectedPort
         {
             get => _selectedPort;
             set => SetProperty(ref _selectedPort, value);
@@ -146,7 +146,7 @@ namespace FirmwareInstaller.ViewModels
         /// <summary>
         /// List of available COM ports.
         /// </summary>
-        public ObservableCollection<string> Ports { get; private set; }
+        public ObservableCollection<COMDevice> Ports { get; private set; }
 
         /// <summary>
         /// List of available versions to download.
@@ -208,7 +208,7 @@ namespace FirmwareInstaller.ViewModels
         {
             SendLog("Discovering COM devices...");
             var ports = _discoveryService.Discover();
-            Ports = new ObservableCollection<string>(ports);
+            Ports = new ObservableCollection<COMDevice>(ports);
 
             SelectedPort = Ports.FirstOrDefault();
         }
@@ -259,7 +259,7 @@ namespace FirmwareInstaller.ViewModels
             {
                 return false;
             }
-            else if(string.IsNullOrEmpty(SelectedPort))
+            else if(SelectedPort is null)
             {
                 return false;
             }
@@ -291,8 +291,8 @@ namespace FirmwareInstaller.ViewModels
                 }
             }
 
-            SendLog($"Installing file {fwFilePath} to {_selectedPort}");
-            await _installService.InstallAsync(fwFilePath, _selectedPort, _useOldBootloader);
+            SendLog($"Installing file {fwFilePath} to {_selectedPort.Port}");
+            await _installService.InstallAsync(fwFilePath, _selectedPort.Port, _useOldBootloader);
 
             IsBusy = false;
         }


### PR DESCRIPTION
## Issues
 - Resolves #100

## Description
Currently, the available devices in FirmwareInstaller are listed by their port name (COM1, COM2..). With those changes, the devices will have the same name as in the device manager (ex: USB-SERIAL CH340 (COM3)).

## Types of changes
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Requested changes are in a branch
- [X] Compiled and tested requested changes on target hardware (PC, device)
- [X] Updated the documentation, if necessary
- [X] Updated the LICENSES file, if necessary
- [X] Reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository


## Further comments

Device are now acquired with a query on `Win32_PnPEntity` instead of a call to `System.IO.Ports.SerialPort.GetPortNames()`.
